### PR TITLE
feat(trends): entity birth/death curve + reusable diff helper (#71)

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,6 +73,7 @@ with open(methodology_notes_path, 'r') as f:
 
 from plots import (
     plot_main_graph,
+    plot_entity_birth_death,
     plot_avg_per_aop,
     plot_network_density,
     plot_ke_components,
@@ -185,6 +186,7 @@ def compute_plots_parallel() -> dict:
     # Define plot functions and their expected results
     plot_tasks = [
         ('main_graph', lambda: safe_plot_execution(plot_main_graph)),
+        ('entity_birth_death', lambda: safe_plot_execution(plot_entity_birth_death)),
         ('avg_per_aop', lambda: safe_plot_execution(plot_avg_per_aop)),
         ('network_density', lambda: safe_plot_execution(plot_network_density)),
         ('ke_components', lambda: safe_plot_execution(plot_ke_components)),
@@ -265,6 +267,13 @@ try:
 except (TypeError, ValueError):
     graph_main_abs = graph_main_delta = ""
     df_all = pd.DataFrame()
+
+try:
+    graph_entity_birth_death, _ = plot_results.get('entity_birth_death', (None, None))
+    if graph_entity_birth_death is None:
+        graph_entity_birth_death = ""
+except (TypeError, ValueError):
+    graph_entity_birth_death = ""
 
 try:
     graph_avg_abs, graph_avg_delta = plot_results.get('avg_per_aop', (None, None))
@@ -1397,13 +1406,13 @@ def download_bulk():
 
             # Trend plots (absolute views only to avoid duplication)
             'trends-all': [
-                'aop_entity_counts_absolute', 'average_components_per_aop_absolute', 'aop_network_density', 'aop_authors_absolute',
+                'aop_entity_counts_absolute', 'entity_birth_death', 'average_components_per_aop_absolute', 'aop_network_density', 'aop_authors_absolute',
                 'aops_created_over_time', 'aops_modified_over_time', 'aop_creation_vs_modification_timeline',
                 'ke_component_annotations_absolute', 'ke_components_percentage_absolute', 'unique_ke_components_absolute',
                 'biological_process_annotations_absolute', 'biological_object_annotations_absolute',
                 'aop_property_presence_absolute', 'aop_property_presence_unique_absolute', 'kes_by_kec_count_absolute'
             ],
-            'trends-main': ['aop_entity_counts_absolute', 'aop_entity_counts_delta'],
+            'trends-main': ['aop_entity_counts_absolute', 'aop_entity_counts_delta', 'entity_birth_death'],
             'trends-network': ['average_components_per_aop_absolute', 'average_components_per_aop_delta', 'aop_network_density'],
             'trends-authors': ['aop_authors_absolute', 'aop_authors_delta', 'aops_created_over_time', 'aops_modified_over_time', 'aop_creation_vs_modification_timeline'],
             'trends-components': [
@@ -1419,7 +1428,7 @@ def download_bulk():
                 'latest_entity_counts', 'latest_ke_components', 'latest_aop_connectivity',
                 'latest_avg_per_aop', 'latest_process_usage', 'latest_object_usage',
                 'latest_aop_completeness', 'latest_ke_annotation_depth',
-                'aop_entity_counts_absolute', 'average_components_per_aop_absolute', 'aop_network_density', 'aop_authors_absolute',
+                'aop_entity_counts_absolute', 'entity_birth_death', 'average_components_per_aop_absolute', 'aop_network_density', 'aop_authors_absolute',
                 'aops_created_over_time', 'aops_modified_over_time', 'aop_creation_vs_modification_timeline',
                 'ke_component_annotations_absolute', 'ke_components_percentage_absolute', 'unique_ke_components_absolute',
                 'biological_process_annotations_absolute', 'biological_object_annotations_absolute',
@@ -1659,6 +1668,7 @@ def get_plot(plot_name):
     plot_map = {
         'aop_entity_counts_absolute': graph_main_abs,
         'aop_entity_counts_delta': graph_main_delta,
+        'entity_birth_death': graph_entity_birth_death,
         'average_components_per_aop_absolute': graph_avg_abs,
         'average_components_per_aop_delta': graph_avg_delta,
         'aop_network_density': graph_density,

--- a/plots/__init__.py
+++ b/plots/__init__.py
@@ -140,6 +140,7 @@ from .shared import (
 from .trends_plots import (
     # Core evolution analysis
     plot_main_graph,
+    plot_entity_birth_death,
     plot_avg_per_aop,
     plot_network_density,
     plot_author_counts,
@@ -262,6 +263,7 @@ __all__ = [
 
     # Historical trends functions
     'plot_main_graph',
+    'plot_entity_birth_death',
     'plot_avg_per_aop',
     'plot_network_density',
     'plot_author_counts',
@@ -328,6 +330,7 @@ def get_available_functions():
     return {
         'historical_trends': [
             'plot_main_graph',
+            'plot_entity_birth_death',
             'plot_avg_per_aop',
             'plot_network_density',
             'plot_author_counts',

--- a/plots/shared.py
+++ b/plots/shared.py
@@ -1042,6 +1042,136 @@ def get_all_versions() -> list[dict]:
         return []
 
 
+# SPARQL class URIs for the four headline entity types tracked across versions
+# (also used by the entity birth/death helper below).
+ENTITY_TYPE_CLASSES: Dict[str, str] = {
+    "AOPs": "aopo:AdverseOutcomePathway",
+    "KEs": "aopo:KeyEvent",
+    "KERs": "aopo:KeyEventRelationship",
+    "Stressors": "nci:C54571",
+}
+
+
+def fetch_entity_uris_in_graph(graph_uri: str, entity_class: str) -> set:
+    """Fetch the set of entity URIs of a given class in a single named graph.
+
+    Args:
+        graph_uri: Full graph URI (e.g. "http://aopwiki.org/graph/2025-07-01").
+        entity_class: Prefixed SPARQL class name (e.g. "aopo:KeyEvent",
+            "nci:C54571"). The endpoint must have the corresponding prefix
+            bound — Virtuoso's AOP-Wiki deployment has aopo/nci preconfigured.
+
+    Returns:
+        set[str]: Set of distinct entity URIs in the graph.
+    """
+    query = f"""
+        SELECT DISTINCT ?e
+        WHERE {{
+            GRAPH <{graph_uri}> {{ ?e a {entity_class} . }}
+        }}
+    """
+    try:
+        results = run_sparql_query_with_retry(query)
+        return {r.get('e', {}).get('value', '') for r in results if r.get('e', {}).get('value')}
+    except Exception as e:
+        logger.error(f"Error fetching entities of class {entity_class} in {graph_uri}: {e}")
+        return set()
+
+
+def diff_entities_between_versions(
+    entity_type: str,
+    versions: Optional[List[str]] = None,
+    max_workers: int = 5,
+) -> pd.DataFrame:
+    """Compute the per-version gross added/removed entity flow ("birth/death" curve).
+
+    For each adjacent snapshot pair (v_prev → v_curr), counts entities that
+    are present in v_curr but not v_prev (added) and present in v_prev but
+    not v_curr (removed). A net delta of zero can hide significant churn —
+    this helper exposes it. Used by `plot_entity_birth_death` (#71) and
+    reusable by other PRs that need version-to-version set differences
+    (#66 KE migration map, #70 curator view, #72 cumulative removals).
+
+    Args:
+        entity_type: One of the keys in `ENTITY_TYPE_CLASSES`
+            ("AOPs", "KEs", "KERs", "Stressors").
+        versions: Optional pre-sorted list of YYYY-MM-DD version strings.
+            If omitted, queried via `get_all_versions()`.
+        max_workers: ThreadPool size for the per-version fetch queries.
+
+    Returns:
+        pd.DataFrame with one row per transition (indexed by v_curr) and
+        columns:
+            - version (str): v_curr (the newer of the pair).
+            - prev_version (str): v_prev.
+            - entity_type (str): the input entity_type.
+            - added_count (int)
+            - removed_count (int)
+            - stable_count (int)
+            - added_uris (str): semicolon-joined list of added URIs.
+            - removed_uris (str): semicolon-joined list of removed URIs.
+        The earliest version has no v_prev and is therefore omitted from
+        the result.
+    """
+    if entity_type not in ENTITY_TYPE_CLASSES:
+        raise ValueError(
+            f"Unknown entity_type {entity_type!r}; expected one of "
+            f"{sorted(ENTITY_TYPE_CLASSES)}"
+        )
+    entity_class = ENTITY_TYPE_CLASSES[entity_type]
+
+    if versions is None:
+        versions = [v['version'] for v in get_all_versions()]
+    # Chronological order (YYYY-MM-DD sorts lexicographically).
+    versions = sorted(set(versions))
+
+    if len(versions) < 2:
+        return pd.DataFrame(columns=[
+            'version', 'prev_version', 'entity_type',
+            'added_count', 'removed_count', 'stable_count',
+            'added_uris', 'removed_uris',
+        ])
+
+    # Fetch entity URI sets per version in parallel.
+    uris_by_version: Dict[str, set] = {}
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {
+            pool.submit(
+                fetch_entity_uris_in_graph,
+                f"http://aopwiki.org/graph/{v}",
+                entity_class,
+            ): v
+            for v in versions
+        }
+        for fut in as_completed(futures):
+            v = futures[fut]
+            try:
+                uris_by_version[v] = fut.result() or set()
+            except Exception as e:
+                logger.error(f"Failed to fetch {entity_type} URIs for {v}: {e}")
+                uris_by_version[v] = set()
+
+    rows = []
+    for prev, curr in zip(versions, versions[1:]):
+        prev_set = uris_by_version.get(prev, set())
+        curr_set = uris_by_version.get(curr, set())
+        added = curr_set - prev_set
+        removed = prev_set - curr_set
+        stable = prev_set & curr_set
+        rows.append({
+            'version': curr,
+            'prev_version': prev,
+            'entity_type': entity_type,
+            'added_count': len(added),
+            'removed_count': len(removed),
+            'stable_count': len(stable),
+            'added_uris': ';'.join(sorted(added)),
+            'removed_uris': ';'.join(sorted(removed)),
+        })
+
+    return pd.DataFrame(rows)
+
+
 def build_export_filename(plot_name: str, format: str, version: str = None) -> str:
     """Build self-documenting export filename with date and optional version.
 

--- a/plots/trends_plots.py
+++ b/plots/trends_plots.py
@@ -61,7 +61,8 @@ from .shared import (
     BRAND_COLORS, config, _plot_data_cache, _plot_figure_cache,
     run_sparql_query, run_sparql_query_with_retry, extract_counts,
     safe_read_csv, create_fallback_plot, get_properties_for_entity,
-    get_all_versions, render_plot_html
+    get_all_versions, render_plot_html,
+    ENTITY_TYPE_CLASSES, diff_entities_between_versions,
 )
 from .organ_systems import (
     ORGAN_SYSTEM_BUCKETS,
@@ -294,6 +295,126 @@ def plot_main_graph() -> tuple[str, str, pd.DataFrame]:
             create_fallback_plot("Entity Evolution Over Time", str(e)),
             create_fallback_plot("Entity Change Between Versions", str(e)),
             pd.DataFrame()
+        )
+
+
+def plot_entity_birth_death() -> tuple[str, pd.DataFrame]:
+    """Gross additions vs removals per snapshot transition (birth/death curve).
+
+    Net entity counts hide churn: a delta of zero can mask "5 new KEs added,
+    5 existing KEs removed/merged/deprecated." This plot exposes both flows
+    by diffing the entity URI set of each pair of adjacent named graphs.
+
+    The result is a faceted diverging bar chart — additions above the zero
+    line, removals below — one panel per entity type. The cached DataFrame
+    also stores the actual added/removed URIs per quarter, so curators can
+    inspect whether removals were intentional.
+
+    See `diff_entities_between_versions` (plots/shared.py) for the
+    underlying set-difference helper; that helper is reused by issues #66,
+    #70, and #72.
+
+    Returns:
+        tuple[str, pd.DataFrame]:
+            - HTML for the faceted diverging-bar plot.
+            - DataFrame with one row per (version, entity_type) transition,
+              columns: version, prev_version, entity_type, added_count,
+              removed_count, stable_count, added_uris, removed_uris.
+    """
+    global _plot_data_cache, _plot_figure_cache
+
+    try:
+        versions = [v['version'] for v in get_all_versions()]
+        versions = sorted(set(versions))
+        if len(versions) < 2:
+            logger.warning("Not enough versions for birth/death curve")
+            return (
+                create_fallback_plot(
+                    "Entity Birth/Death Curve",
+                    "Need at least two snapshot versions to compute a diff."
+                ),
+                pd.DataFrame(),
+            )
+
+        # Run the four entity types in parallel — each spawns its own per-version
+        # fetch pool internally. Cap workers at 4 since there are 4 types.
+        per_type_dfs: list[pd.DataFrame] = []
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = {
+                pool.submit(diff_entities_between_versions, entity_type, versions): entity_type
+                for entity_type in ENTITY_TYPE_CLASSES
+            }
+            for fut in as_completed(futures):
+                entity_type = futures[fut]
+                try:
+                    per_type_dfs.append(fut.result())
+                except Exception as e:
+                    logger.error(f"Birth/death diff failed for {entity_type}: {e}")
+
+        if not per_type_dfs:
+            return (
+                create_fallback_plot("Entity Birth/Death Curve", "No diff data available"),
+                pd.DataFrame(),
+            )
+
+        df = pd.concat(per_type_dfs, ignore_index=True)
+        # Stable chronological + entity ordering for downstream UX.
+        entity_order = list(ENTITY_TYPE_CLASSES.keys())
+        df['entity_type'] = pd.Categorical(df['entity_type'], categories=entity_order, ordered=True)
+        df = df.sort_values(['entity_type', 'version']).reset_index(drop=True)
+
+        # Long-form frame for plotly: signed bars — additions positive, removals negative.
+        plot_df = pd.concat([
+            df.assign(
+                Direction='Added',
+                Count=df['added_count'].astype(int),
+            )[['version', 'entity_type', 'Direction', 'Count']],
+            df.assign(
+                Direction='Removed',
+                Count=-df['removed_count'].astype(int),
+            )[['version', 'entity_type', 'Direction', 'Count']],
+        ], ignore_index=True)
+
+        fig = px.bar(
+            plot_df,
+            x='version',
+            y='Count',
+            color='Direction',
+            facet_col='entity_type',
+            facet_col_wrap=2,
+            category_orders={
+                'entity_type': entity_order,
+                'Direction': ['Added', 'Removed'],
+            },
+            color_discrete_map={
+                'Added': BRAND_COLORS['magenta'],
+                'Removed': BRAND_COLORS['primary'],
+            },
+            labels={'version': 'Snapshot', 'Count': 'Entities (added / removed)'},
+        )
+        # Per-facet title cleanup: "entity_type=AOPs" → "AOPs".
+        fig.for_each_annotation(lambda a: a.update(text=a.text.split('=')[-1]))
+        # Free y-axes so KEs/KERs don't squash AOP/Stressor panels.
+        fig.update_yaxes(matches=None, showticklabels=True)
+        fig.update_xaxes(tickangle=-45)
+        fig.add_hline(y=0, line_dash='dot', line_color='#888', line_width=1)
+        fig.update_layout(
+            barmode='relative',
+            margin=dict(l=60, r=30, t=50, b=80),
+            height=600,
+            legend=dict(orientation='h', yanchor='bottom', y=1.02, xanchor='right', x=1.0),
+        )
+
+        _plot_data_cache['entity_birth_death'] = df
+        _plot_figure_cache['entity_birth_death'] = fig
+
+        return render_plot_html(fig), df
+
+    except Exception as e:
+        logger.error(f"Failed to generate entity birth/death plot: {str(e)}")
+        return (
+            create_fallback_plot("Entity Birth/Death Curve", str(e)),
+            pd.DataFrame(),
         )
 
 

--- a/static/data/methodology_notes.json
+++ b/static/data/methodology_notes.json
@@ -203,6 +203,13 @@
         "limitations": "Data reflects the RDF transformation, not the raw AOP-Wiki database. Entity counts include all instances regardless of completeness or quality. Some versions may have data quality variations due to changes in the RDF conversion pipeline. Trend data covers only the published RDF release versions available in the SPARQL endpoint; the AOP-Wiki knowledge base predates the earliest RDF release, so earlier activity is not captured.",
         "sparql": "SELECT ?graph (COUNT(?aop) AS ?count)\nWHERE {\n  GRAPH ?graph {\n    ?aop a aopo:AdverseOutcomePathway .\n  }\n}\nGROUP BY ?graph\nORDER BY ?graph"
     },
+    "entity_birth_death": {
+        "title": "Entity Birth/Death Curve",
+        "description": "Gross additions vs removals per snapshot transition, one panel per entity type. Additions appear above the zero line, removals below. The AOP Entity Counts plot above shows net change — a delta of zero can still hide significant churn (e.g. five new KEs added while five existing KEs were merged or deprecated). This view exposes both flows.",
+        "data_source": "For each entity class (AOPs, KEs, KERs, Stressors), the distinct set of entity URIs is fetched per named graph using the query below; consecutive snapshots are then diffed in Python. `added` = present in v_curr but not v_prev, `removed` = present in v_prev but not v_curr. An equivalent endpoint-side computation would substitute two graph URIs into a `GRAPH <v_curr> { … } MINUS { GRAPH <v_prev> { … } }` pattern. The downloadable CSV preserves the actual added/removed URIs per quarter for curator follow-up.",
+        "limitations": "Only entities present as `a aopo:AdverseOutcomePathway` / `aopo:KeyEvent` / `aopo:KeyEventRelationship` / `nci:C54571` are tracked. A URI changing identifier between versions (re-minted) will look like a removal + addition; merges or splits will look similar. The earliest snapshot has no predecessor and is therefore omitted. Trend data covers only the published RDF release versions available in the SPARQL endpoint.",
+        "sparql": "SELECT DISTINCT ?e\nWHERE {\n  GRAPH __GRAPH_URI__ { ?e a aopo:KeyEvent . }\n}"
+    },
     "aop_property_presence": {
         "title": "AOP Property Presence Over Time",
         "description": "Tracks which metadata properties are present in AOPs over time. Shows absolute counts of AOPs containing each property per version. Properties that are always 100% present are excluded to highlight meaningful variation in documentation completeness.",

--- a/templates/trends.html
+++ b/templates/trends.html
@@ -44,6 +44,34 @@
     </div>
 
 
+    <!-- Entity Birth/Death Curve (#71) -->
+    <div class="plot-box full-width" id="entity-birth-death">
+        <div class="plot-header">
+            <h3>Entity Birth/Death Curve</h3>
+            <div style="display: flex; gap: 10px; align-items: center;">
+                <div class="download-dropdown">
+                    <button class="download-button dropdown-toggle">Download ▼</button>
+                    <div class="dropdown-menu">
+                        <a href="/download/trend/entity_birth_death?format=csv" class="dropdown-item">📄 CSV</a>
+                        <a href="/download/trend/entity_birth_death?format=png" class="dropdown-item">🖼️ PNG</a>
+                        <a href="/download/trend/entity_birth_death?format=svg" class="dropdown-item">📐 SVG</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <p class="plot-description">
+            Gross additions vs removals between adjacent snapshots — one panel per entity type.
+            Additions sit above the zero line, removals below. A net delta of zero (cf. the chart above)
+            can still hide churn; this view exposes it. The CSV includes the URIs of every entity that
+            was added or removed per quarter, for curator follow-up.
+        </p>
+        {{ methodology_note(methodology_notes, 'entity_birth_death') }}
+        <div class="lazy-plot" data-plot-name="entity_birth_death">
+            <!-- Plot will be loaded here via JavaScript -->
+        </div>
+        {{ data_table_toggle('entity_birth_death') }}
+    </div>
+
 
     <!-- AOP Property Presence -->
     <div class="plot-box full-width" id="aop-property-presence">


### PR DESCRIPTION
Closes #71.

## What this adds

A new **Entity Birth/Death Curve** plot on `/trends`, sitting under *AOP Entity Counts* in the Main Trends section. For each adjacent quarterly snapshot it shows the **gross** flow of entities — additions above the zero line, removals below — in a faceted diverging bar chart (one panel per AOPs, KEs, KERs, Stressors).

Net entity counts hide churn: a `Δ = 0` quarter can still have five new KEs added and five existing KEs removed/merged/deprecated. This view exposes both flows.

The downloadable CSV preserves the actual added/removed URIs per quarter (`added_uris`, `removed_uris` columns), so curators can check whether a removal was intentional or a glitch.

## What this adds for the rest of the v1.3 queue

A reusable `diff_entities_between_versions(entity_type, versions)` helper in `plots/shared.py`, alongside `fetch_entity_uris_in_graph` and an `ENTITY_TYPE_CLASSES` constant. The helper diffs entity URI sets between all adjacent `(v_prev, v_curr)` pairs in chronological order. Designed to be reused by:

- #66 — KE migration map across quarterly snapshots
- #70 — curator's *what to work on next* view (recent additions)
- #72 — cumulative count of entities that once existed but are no longer in the database

## Live-endpoint validation

Smoke-tested against `aopwiki-multirdf.vhp4safety.nl` across all 32 quarterly snapshots:

| Entity type | Total added (history) | Total removed (history) |
|---|---|---|
| AOPs       | 367  | 2   |
| KEs        | 829  | 167 |
| KERs       | 1782 | 528 |
| Stressors  | 474  | 42  |

The 2025→2026 KE transition alone has +31 added and −1 removed — exactly the kind of asymmetry that net deltas hide.

## Wiring

- `plots/shared.py` — `ENTITY_TYPE_CLASSES`, `fetch_entity_uris_in_graph`, `diff_entities_between_versions`
- `plots/trends_plots.py` — `plot_entity_birth_death`
- `plots/__init__.py` — export
- `app.py` — startup task, result unpacking, `/api/plot/<plot_name>` mapping, `trends-main` / `trends-all` / `all` bulk-download categories
- `templates/trends.html` — full-width plot box right after `aop_entity_counts`
- `static/data/methodology_notes.json` — new `entity_birth_death` entry with `__GRAPH_URI__` (passes LINT-01 against the live endpoint)

## Test plan

- [x] `python3 -m pytest tests/ -x -q` — 20 passed
- [x] `python3 scripts/lint_methodology.py --json static/data/methodology_notes.json --no-network --plots-dir plots` — 0 failures, 0 warnings
- [x] Live SPARQL query against `aopwiki-multirdf.vhp4safety.nl` returns expected counts
- [x] `plot_entity_birth_death()` runs end-to-end against the live endpoint and returns 128 rows of diff data + a 17KB HTML figure
- [ ] Visual sanity check after deploy: birth/death panel renders, removed-URIs CSV download has the right columns