### PR TITLE
feat(trends): cumulative removed entities — running graveyard view (#72)

### DIFF
--- a/app.py
+++ b/app.py
@@ -74,6 +74,7 @@ with open(methodology_notes_path, 'r') as f:
 from plots import (
     plot_main_graph,
     plot_entity_birth_death,
+    plot_entity_cumulative_removed,
     plot_avg_per_aop,
     plot_network_density,
     plot_ke_components,
@@ -187,6 +188,7 @@ def compute_plots_parallel() -> dict:
     plot_tasks = [
         ('main_graph', lambda: safe_plot_execution(plot_main_graph)),
         ('entity_birth_death', lambda: safe_plot_execution(plot_entity_birth_death)),
+        ('entity_cumulative_removed', lambda: safe_plot_execution(plot_entity_cumulative_removed)),
         ('avg_per_aop', lambda: safe_plot_execution(plot_avg_per_aop)),
         ('network_density', lambda: safe_plot_execution(plot_network_density)),
         ('ke_components', lambda: safe_plot_execution(plot_ke_components)),
@@ -274,6 +276,13 @@ try:
         graph_entity_birth_death = ""
 except (TypeError, ValueError):
     graph_entity_birth_death = ""
+
+try:
+    graph_entity_cumulative_removed, _ = plot_results.get('entity_cumulative_removed', (None, None))
+    if graph_entity_cumulative_removed is None:
+        graph_entity_cumulative_removed = ""
+except (TypeError, ValueError):
+    graph_entity_cumulative_removed = ""
 
 try:
     graph_avg_abs, graph_avg_delta = plot_results.get('avg_per_aop', (None, None))
@@ -1406,13 +1415,13 @@ def download_bulk():
 
             # Trend plots (absolute views only to avoid duplication)
             'trends-all': [
-                'aop_entity_counts_absolute', 'entity_birth_death', 'average_components_per_aop_absolute', 'aop_network_density', 'aop_authors_absolute',
+                'aop_entity_counts_absolute', 'entity_birth_death', 'entity_cumulative_removed', 'average_components_per_aop_absolute', 'aop_network_density', 'aop_authors_absolute',
                 'aops_created_over_time', 'aops_modified_over_time', 'aop_creation_vs_modification_timeline',
                 'ke_component_annotations_absolute', 'ke_components_percentage_absolute', 'unique_ke_components_absolute',
                 'biological_process_annotations_absolute', 'biological_object_annotations_absolute',
                 'aop_property_presence_absolute', 'aop_property_presence_unique_absolute', 'kes_by_kec_count_absolute'
             ],
-            'trends-main': ['aop_entity_counts_absolute', 'aop_entity_counts_delta', 'entity_birth_death'],
+            'trends-main': ['aop_entity_counts_absolute', 'aop_entity_counts_delta', 'entity_birth_death', 'entity_cumulative_removed'],
             'trends-network': ['average_components_per_aop_absolute', 'average_components_per_aop_delta', 'aop_network_density'],
             'trends-authors': ['aop_authors_absolute', 'aop_authors_delta', 'aops_created_over_time', 'aops_modified_over_time', 'aop_creation_vs_modification_timeline'],
             'trends-components': [
@@ -1428,7 +1437,7 @@ def download_bulk():
                 'latest_entity_counts', 'latest_ke_components', 'latest_aop_connectivity',
                 'latest_avg_per_aop', 'latest_process_usage', 'latest_object_usage',
                 'latest_aop_completeness', 'latest_ke_annotation_depth',
-                'aop_entity_counts_absolute', 'entity_birth_death', 'average_components_per_aop_absolute', 'aop_network_density', 'aop_authors_absolute',
+                'aop_entity_counts_absolute', 'entity_birth_death', 'entity_cumulative_removed', 'average_components_per_aop_absolute', 'aop_network_density', 'aop_authors_absolute',
                 'aops_created_over_time', 'aops_modified_over_time', 'aop_creation_vs_modification_timeline',
                 'ke_component_annotations_absolute', 'ke_components_percentage_absolute', 'unique_ke_components_absolute',
                 'biological_process_annotations_absolute', 'biological_object_annotations_absolute',
@@ -1669,6 +1678,7 @@ def get_plot(plot_name):
         'aop_entity_counts_absolute': graph_main_abs,
         'aop_entity_counts_delta': graph_main_delta,
         'entity_birth_death': graph_entity_birth_death,
+        'entity_cumulative_removed': graph_entity_cumulative_removed,
         'average_components_per_aop_absolute': graph_avg_abs,
         'average_components_per_aop_delta': graph_avg_delta,
         'aop_network_density': graph_density,

--- a/plots/__init__.py
+++ b/plots/__init__.py
@@ -141,6 +141,7 @@ from .trends_plots import (
     # Core evolution analysis
     plot_main_graph,
     plot_entity_birth_death,
+    plot_entity_cumulative_removed,
     plot_avg_per_aop,
     plot_network_density,
     plot_author_counts,
@@ -264,6 +265,7 @@ __all__ = [
     # Historical trends functions
     'plot_main_graph',
     'plot_entity_birth_death',
+    'plot_entity_cumulative_removed',
     'plot_avg_per_aop',
     'plot_network_density',
     'plot_author_counts',
@@ -331,6 +333,7 @@ def get_available_functions():
         'historical_trends': [
             'plot_main_graph',
             'plot_entity_birth_death',
+            'plot_entity_cumulative_removed',
             'plot_avg_per_aop',
             'plot_network_density',
             'plot_author_counts',

--- a/plots/shared.py
+++ b/plots/shared.py
@@ -1078,6 +1078,52 @@ def fetch_entity_uris_in_graph(graph_uri: str, entity_class: str) -> set:
         return set()
 
 
+def fetch_entity_uris_by_version(
+    entity_type: str,
+    versions: List[str],
+    max_workers: int = 5,
+) -> Dict[str, set]:
+    """Fetch the entity URI set for one class across all given versions in parallel.
+
+    Internal helper shared by `diff_entities_between_versions` (#71) and by
+    the cumulative-removed view (#72). Centralised so both views run the
+    same per-version fetch implementation.
+
+    Args:
+        entity_type: A key in `ENTITY_TYPE_CLASSES`.
+        versions: List of YYYY-MM-DD version strings to fetch.
+        max_workers: ThreadPool size for the parallel per-version queries.
+
+    Returns:
+        dict[version_str, set[str]]: Per-version sets of distinct entity URIs.
+        Versions whose query fails resolve to an empty set (logged).
+    """
+    if entity_type not in ENTITY_TYPE_CLASSES:
+        raise ValueError(
+            f"Unknown entity_type {entity_type!r}; expected one of "
+            f"{sorted(ENTITY_TYPE_CLASSES)}"
+        )
+    entity_class = ENTITY_TYPE_CLASSES[entity_type]
+    uris_by_version: Dict[str, set] = {}
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {
+            pool.submit(
+                fetch_entity_uris_in_graph,
+                f"http://aopwiki.org/graph/{v}",
+                entity_class,
+            ): v
+            for v in versions
+        }
+        for fut in as_completed(futures):
+            v = futures[fut]
+            try:
+                uris_by_version[v] = fut.result() or set()
+            except Exception as e:
+                logger.error(f"Failed to fetch {entity_type} URIs for {v}: {e}")
+                uris_by_version[v] = set()
+    return uris_by_version
+
+
 def diff_entities_between_versions(
     entity_type: str,
     versions: Optional[List[str]] = None,
@@ -1113,13 +1159,6 @@ def diff_entities_between_versions(
         The earliest version has no v_prev and is therefore omitted from
         the result.
     """
-    if entity_type not in ENTITY_TYPE_CLASSES:
-        raise ValueError(
-            f"Unknown entity_type {entity_type!r}; expected one of "
-            f"{sorted(ENTITY_TYPE_CLASSES)}"
-        )
-    entity_class = ENTITY_TYPE_CLASSES[entity_type]
-
     if versions is None:
         versions = [v['version'] for v in get_all_versions()]
     # Chronological order (YYYY-MM-DD sorts lexicographically).
@@ -1132,24 +1171,7 @@ def diff_entities_between_versions(
             'added_uris', 'removed_uris',
         ])
 
-    # Fetch entity URI sets per version in parallel.
-    uris_by_version: Dict[str, set] = {}
-    with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        futures = {
-            pool.submit(
-                fetch_entity_uris_in_graph,
-                f"http://aopwiki.org/graph/{v}",
-                entity_class,
-            ): v
-            for v in versions
-        }
-        for fut in as_completed(futures):
-            v = futures[fut]
-            try:
-                uris_by_version[v] = fut.result() or set()
-            except Exception as e:
-                logger.error(f"Failed to fetch {entity_type} URIs for {v}: {e}")
-                uris_by_version[v] = set()
+    uris_by_version = fetch_entity_uris_by_version(entity_type, versions, max_workers=max_workers)
 
     rows = []
     for prev, curr in zip(versions, versions[1:]):

--- a/plots/trends_plots.py
+++ b/plots/trends_plots.py
@@ -63,6 +63,7 @@ from .shared import (
     safe_read_csv, create_fallback_plot, get_properties_for_entity,
     get_all_versions, render_plot_html,
     ENTITY_TYPE_CLASSES, diff_entities_between_versions,
+    fetch_entity_uris_by_version,
 )
 from .organ_systems import (
     ORGAN_SYSTEM_BUCKETS,
@@ -414,6 +415,114 @@ def plot_entity_birth_death() -> tuple[str, pd.DataFrame]:
         logger.error(f"Failed to generate entity birth/death plot: {str(e)}")
         return (
             create_fallback_plot("Entity Birth/Death Curve", str(e)),
+            pd.DataFrame(),
+        )
+
+
+def plot_entity_cumulative_removed() -> tuple[str, pd.DataFrame]:
+    """Running graveyard view — entities that once existed and are now absent.
+
+    Companion to `plot_entity_birth_death` (#71): #71 shows the *flow*
+    (per-quarter births and deaths); this plot shows the *stock* (total
+    ever-removed up to each snapshot).
+
+    For each snapshot N and entity type, the count is
+    ``len(union(URIs in graphs ≤ N) − URIs in N)`` — entities seen at any
+    earlier point but absent right now. An entity that disappears in v_N
+    and reappears in v_{N+2} is counted in N and N+1 but not in N+2; the
+    line is monotonic modulo re-additions.
+
+    The downloadable CSV preserves the actual absent URIs per snapshot so
+    curators can audit a concrete "deprecated entities" list.
+
+    Returns:
+        tuple[str, pd.DataFrame]:
+            - HTML for a 4-trace line chart (one trace per entity type).
+            - DataFrame with columns: version, entity_type,
+              cumulative_removed_count, removed_uris.
+    """
+    global _plot_data_cache, _plot_figure_cache
+
+    try:
+        versions = sorted({v['version'] for v in get_all_versions()})
+        if len(versions) < 2:
+            logger.warning("Not enough versions for cumulative-removed curve")
+            return (
+                create_fallback_plot(
+                    "Cumulative Removed Entities",
+                    "Need at least two snapshot versions to compute the running set."
+                ),
+                pd.DataFrame(),
+            )
+
+        # Each entity type runs its own per-version fetch pool (5 workers each).
+        # Cap the outer pool at 4 since there are 4 entity types.
+        per_type_uris: dict[str, dict[str, set]] = {}
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = {
+                pool.submit(fetch_entity_uris_by_version, entity_type, versions): entity_type
+                for entity_type in ENTITY_TYPE_CLASSES
+            }
+            for fut in as_completed(futures):
+                entity_type = futures[fut]
+                try:
+                    per_type_uris[entity_type] = fut.result()
+                except Exception as e:
+                    logger.error(f"Cumulative-removed fetch failed for {entity_type}: {e}")
+                    per_type_uris[entity_type] = {v: set() for v in versions}
+
+        rows = []
+        for entity_type in ENTITY_TYPE_CLASSES:
+            uris_by_version = per_type_uris.get(entity_type, {})
+            ever_seen: set[str] = set()
+            for v in versions:
+                current = uris_by_version.get(v, set())
+                ever_seen |= current
+                # Entities seen at any earlier point AND absent in the current snapshot.
+                absent_now = ever_seen - current
+                rows.append({
+                    'version': v,
+                    'entity_type': entity_type,
+                    'cumulative_removed_count': len(absent_now),
+                    'removed_uris': ';'.join(sorted(absent_now)),
+                })
+
+        df = pd.DataFrame(rows)
+        entity_order = list(ENTITY_TYPE_CLASSES.keys())
+        df['entity_type'] = pd.Categorical(df['entity_type'], categories=entity_order, ordered=True)
+        df = df.sort_values(['entity_type', 'version']).reset_index(drop=True)
+
+        fig = px.line(
+            df,
+            x='version',
+            y='cumulative_removed_count',
+            color='entity_type',
+            markers=True,
+            category_orders={'entity_type': entity_order},
+            color_discrete_sequence=BRAND_COLORS['palette'],
+            labels={
+                'version': 'Snapshot',
+                'cumulative_removed_count': 'Entities ever-removed and currently absent',
+                'entity_type': 'Entity type',
+            },
+        )
+        fig.update_xaxes(
+            tickmode='array',
+            tickvals=versions,
+            ticktext=versions,
+            tickangle=-45,
+        )
+        fig.update_layout(margin=dict(l=60, r=30, t=50, b=80))
+
+        _plot_data_cache['entity_cumulative_removed'] = df
+        _plot_figure_cache['entity_cumulative_removed'] = fig
+
+        return render_plot_html(fig), df
+
+    except Exception as e:
+        logger.error(f"Failed to generate cumulative-removed plot: {str(e)}")
+        return (
+            create_fallback_plot("Cumulative Removed Entities", str(e)),
             pd.DataFrame(),
         )
 

--- a/static/data/methodology_notes.json
+++ b/static/data/methodology_notes.json
@@ -210,6 +210,13 @@
         "limitations": "Only entities present as `a aopo:AdverseOutcomePathway` / `aopo:KeyEvent` / `aopo:KeyEventRelationship` / `nci:C54571` are tracked. A URI changing identifier between versions (re-minted) will look like a removal + addition; merges or splits will look similar. The earliest snapshot has no predecessor and is therefore omitted. Trend data covers only the published RDF release versions available in the SPARQL endpoint.",
         "sparql": "SELECT DISTINCT ?e\nWHERE {\n  GRAPH __GRAPH_URI__ { ?e a aopo:KeyEvent . }\n}"
     },
+    "entity_cumulative_removed": {
+        "title": "Cumulative Removed Entities",
+        "description": "For each snapshot N, the running count of entities that appeared in any earlier snapshot but are absent in N. One trace per entity type (AOPs, KEs, KERs, Stressors). Companion to the birth/death curve above: that plot shows per-quarter flow (births and deaths), this one shows the accumulated stock of attrition. A re-addition (URI absent in v_N but back in v_{N+1}) decrements the line.",
+        "data_source": "The same per-graph entity URI fetch as Entity Birth/Death (the query below, run once per snapshot per entity class). For each entity type we then walk snapshots chronologically, maintain the running union of all URIs ever seen, and at each step count `(ever_seen_through_N) − URIs_in_N` — entities seen at any earlier point AND absent right now. The downloadable CSV lists every absent URI per snapshot.",
+        "limitations": "Counts only entities typed as `a aopo:AdverseOutcomePathway` / `aopo:KeyEvent` / `aopo:KeyEventRelationship` / `nci:C54571`. A URI re-minted between snapshots will look like a removal even if the entity semantically still exists. The earliest snapshot is always 0 (nothing has been seen yet). Trend data covers only the published RDF release versions available in the SPARQL endpoint.",
+        "sparql": "SELECT DISTINCT ?e\nWHERE {\n  GRAPH __GRAPH_URI__ { ?e a aopo:KeyEvent . }\n}"
+    },
     "aop_property_presence": {
         "title": "AOP Property Presence Over Time",
         "description": "Tracks which metadata properties are present in AOPs over time. Shows absolute counts of AOPs containing each property per version. Properties that are always 100% present are excluded to highlight meaningful variation in documentation completeness.",

--- a/templates/trends.html
+++ b/templates/trends.html
@@ -73,6 +73,36 @@
     </div>
 
 
+    <!-- Cumulative Removed Entities (#72) -->
+    <div class="plot-box full-width" id="entity-cumulative-removed">
+        <div class="plot-header">
+            <h3>Cumulative Removed Entities</h3>
+            <div style="display: flex; gap: 10px; align-items: center;">
+                <div class="download-dropdown">
+                    <button class="download-button dropdown-toggle">Download ▼</button>
+                    <div class="dropdown-menu">
+                        <a href="/download/trend/entity_cumulative_removed?format=csv" class="dropdown-item">📄 CSV</a>
+                        <a href="/download/trend/entity_cumulative_removed?format=png" class="dropdown-item">🖼️ PNG</a>
+                        <a href="/download/trend/entity_cumulative_removed?format=svg" class="dropdown-item">📐 SVG</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <p class="plot-description">
+            Running graveyard view — for each snapshot, the count of entities that appeared in any
+            earlier snapshot but are absent now. Companion to the birth/death curve above:
+            that view shows per-quarter <em>flow</em>, this one shows accumulated <em>stock</em>.
+            Re-additions decrement the line. The CSV lists every absent URI per snapshot so curators
+            can audit deprecations.
+        </p>
+        {{ methodology_note(methodology_notes, 'entity_cumulative_removed') }}
+        <div class="lazy-plot" data-plot-name="entity_cumulative_removed">
+            <!-- Plot will be loaded here via JavaScript -->
+        </div>
+        {{ data_table_toggle('entity_cumulative_removed') }}
+    </div>
+
+
     <!-- AOP Property Presence -->
     <div class="plot-box full-width" id="aop-property-presence">
         <div class="plot-header">


### PR DESCRIPTION
Closes #72. **Stacked on top of #78 (PR for #71)** — review/merge #78 first; this PR's diff against `main` will get smaller automatically once that lands.

## What this adds

A new **Cumulative Removed Entities** plot on `/trends`, sitting under *Entity Birth/Death Curve* in the Main Trends section. For each snapshot N and entity type, the count is `len(union(URIs in graphs ≤ N) − URIs in N)` — entities seen at any earlier point but absent right now.

Companion to #71:
- #71 (the birth/death curve) shows per-quarter **flow** — births and deaths.
- This one shows the accumulated **stock** of attrition.

A re-addition (URI absent in v_N but back in v_{N+1}) decrements the line, so the curve is monotonic modulo re-additions.

## Shared helper extraction

Factors `fetch_entity_uris_by_version(entity_type, versions)` out of `diff_entities_between_versions` in `plots/shared.py` so both views share a single per-version fetch implementation. The refactor is behavior-preserving — `diff_entities_between_versions` returns the same numbers as before.

## Live-endpoint validation

Smoke-tested against `aopwiki-multirdf.vhp4safety.nl` (latest snapshot, *currently-absent* counts):

| Entity type | Currently absent | Total ever removed (from #71) | Re-additions |
|---|---|---|---|
| AOPs       | 2   | 2   | 0  |
| KEs        | 145 | 167 | ~22 |
| KERs       | 514 | 528 | ~14 |
| Stressors  | 30  | 42  | 12 |

The gap between the two views is itself a useful signal — re-additions indicate entities that came back, suggesting reversible churn.

## Wiring

- `plots/shared.py` — `fetch_entity_uris_by_version` factored out; `diff_entities_between_versions` slimmed to use it
- `plots/trends_plots.py` — `plot_entity_cumulative_removed`
- `plots/__init__.py` — export
- `app.py` — startup task, result unpacking, `/api/plot/<plot_name>` mapping, `trends-main` / `trends-all` / `all` bulk-download categories
- `templates/trends.html` — full-width plot box right after the birth/death block
- `static/data/methodology_notes.json` — new `entity_cumulative_removed` entry with `__GRAPH_URI__` (passes LINT-01 against the live endpoint)

## Test plan

- [x] `python3 -m pytest tests/ -x -q` — 20 passed
- [x] `python3 scripts/lint_methodology.py --json static/data/methodology_notes.json --no-network --plots-dir plots` — 0 failures, 0 warnings
- [x] Refactored `diff_entities_between_versions` returns identical numbers to #71's smoke-test baseline (KEs: 829 added / 167 removed)
- [x] `plot_entity_cumulative_removed()` runs end-to-end against the live endpoint and returns 132 rows of stock data + a 13KB HTML figure
- [ ] Visual sanity check after deploy: cumulative-removed panel renders, removed-URIs CSV download has the right columns