### PR TITLE
chore(ci): bump GHA actions to Node-24-compatible majors

### DIFF
--- a/.github/workflows/download-audit.yml
+++ b/.github/workflows/download-audit.yml
@@ -41,10 +41,10 @@ jobs:
       SPARQL_PUBLIC_ENDPOINT: https://aopwiki-multirdf.vhp4safety.nl/sparql
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: pip

--- a/.github/workflows/methodology-lint.yml
+++ b/.github/workflows/methodology-lint.yml
@@ -43,10 +43,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: pip
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: methodology-lint-report
           path: |

--- a/.github/workflows/upload-plots-zenodo.yml
+++ b/.github/workflows/upload-plots-zenodo.yml
@@ -25,7 +25,7 @@ jobs:
       ZENODO_PLOTS_DEPOSITION_ID: ${{ secrets.ZENODO_PLOTS_DEPOSITION_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Guard — is the record configured?
         run: |
@@ -39,7 +39,7 @@ jobs:
 
       - name: Set up Python
         if: env.configured == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: pip


### PR DESCRIPTION
Bumps all `.github/workflows/` actions to Node-24-compatible majors ahead of the 2026-06-02 forced runner switch.

| Action | Was | Now |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-python | v5 | v6 |
| actions/upload-artifact | v4 | v7 |

Audited all three workflow files (`methodology-lint.yml`, `download-audit.yml`, `upload-plots-zenodo.yml`); no third-party actions present. Majors verified as the latest against github/actions at time of bump.

Closes #74