### PR TITLE
feat(bulk-download): embed snapshot range in ZIP filename

### DIFF
--- a/app.py
+++ b/app.py
@@ -1600,11 +1600,12 @@ def download_bulk():
         if not zip_bytes:
             return "Failed to create bulk download", 500
 
-        # Generate filename
+        # Generate filename, embedding the snapshot range when one is active (#59)
+        suffix = f"_{start or ''}_to_{end or ''}" if (start or end) else ""
         if category:
-            filename = f"aopwiki_{category}_plots.zip"
+            filename = f"aopwiki_{category}{suffix}_plots.zip"
         else:
-            filename = f"aopwiki_{len(plot_names)}_plots.zip"
+            filename = f"aopwiki_{len(plot_names)}{suffix}_plots.zip"
 
         return Response(
             zip_bytes,


### PR DESCRIPTION
When the `/trends` date-range selector is active, the bulk-download ZIP contents already honour the range, but the filename was always `aopwiki_<category>_plots.zip` — so windows stashed on disk were indistinguishable.

Now filtered bulk downloads land as e.g.:

```
aopwiki_trends-all_2022-01-01_to_2024-01-01_plots.zip
```

Unfiltered downloads are unchanged. A partial bound (only `start` or only `end`) renders the present side and leaves the other empty rather than emitting literal `None`.

Closes #59