### PR TITLE
feat(trends): scope methodology SPARQL panel to active range

### DIFF
--- a/static/js/trends-range-selector.js
+++ b/static/js/trends-range-selector.js
@@ -147,6 +147,7 @@
         updateStatus();
         updateURLState();
         updateDownloadLinks();
+        updateMethodologyQueries();
         if (!skipPlotRelayout) relayoutAllPlots();
     }
 
@@ -203,6 +204,72 @@
             // Preserve any path-only links (no host)
             const newHref = url.pathname + (url.search || '');
             a.setAttribute('href', newHref);
+        });
+    }
+
+    // Graph-IRI prefix shared by every snapshot named graph.
+    const GRAPH_PREFIX = 'http://aopwiki.org/graph/';
+
+    /**
+     * Keep the methodology "Run on Endpoint" / "Copy Query" panels in sync with
+     * the active range (#62). Only the multi-graph trend queries — those that
+     * iterate `GRAPH ?graph { ... } GROUP BY ?graph` — are rewritten; the
+     * single-snapshot illustrative queries (`GRAPH <.../YYYY-MM-DD>`) are left
+     * untouched because a range doesn't apply to them.
+     *
+     * Graph IRIs sort lexicographically (constant prefix + zero-padded ISO
+     * date), so a `STR(?graph) >= lo && STR(?graph) <= hi` bound selects exactly
+     * the snapshots in the window. The pristine query is cached on first touch
+     * so toggling back to the full range (or picking a different window) always
+     * rewrites from the original rather than compounding edits.
+     */
+    function updateMethodologyQueries() {
+        const rangeClause =
+            `STR(?graph) >= "${GRAPH_PREFIX}${startVersion}" && ` +
+            `STR(?graph) <= "${GRAPH_PREFIX}${endVersion}"`;
+        const multiGraph = /GRAPH\s+\?graph\b/;
+        const strStarts = `STRSTARTS(STR(?graph), "${GRAPH_PREFIX}")`;
+        const fullRange = isFullRange();
+
+        document.querySelectorAll('details.sparql-query').forEach((panel) => {
+            const code = panel.querySelector('code');
+            if (!code) return;
+
+            // Cache the pristine query once; skip non-multi-graph queries.
+            if (code.dataset.origQuery === undefined) {
+                if (!multiGraph.test(code.textContent)) return;
+                code.dataset.origQuery = code.textContent;
+            }
+            const original = code.dataset.origQuery;
+
+            let updated = original;
+            if (!fullRange) {
+                if (original.indexOf(strStarts) !== -1) {
+                    // Augment the existing graph-prefix filter.
+                    updated = original.replace(strStarts, `${strStarts} && ${rangeClause}`);
+                } else {
+                    // No prefix filter present — inject one inside the first
+                    // `GRAPH ?graph {` block, where ?graph is in scope.
+                    updated = original.replace(
+                        /(GRAPH\s+\?graph\s*\{)/,
+                        `$1\n    FILTER(${rangeClause})`
+                    );
+                }
+            }
+
+            if (updated === code.textContent) return;
+            code.textContent = updated;
+
+            const link = panel.querySelector('a.sparql-run-btn');
+            if (link && link.href) {
+                try {
+                    const url = new URL(link.href);
+                    url.searchParams.set('query', updated);
+                    link.href = url.toString();
+                } catch (e) {
+                    console.warn('trends-range-selector: could not rebuild Run-on-Endpoint href', e);
+                }
+            }
         });
     }
 

--- a/templates/trends_page.html
+++ b/templates/trends_page.html
@@ -53,7 +53,7 @@
     <p>
         Evolution and growth patterns of the AOP-Wiki database over time, using quarterly releases.
         Toggle the global <strong>Delta Mode</strong> button at the top to switch every plot between absolute counts and per-version deltas, or use the per-plot checkbox.
-        Use the <strong>Range</strong> selectors to constrain every snapshot-keyed plot to a sub-window; CSV/PNG/SVG downloads honour the same window.
+        Use the <strong>Range</strong> selectors to constrain every snapshot-keyed plot to a sub-window; CSV/PNG/SVG downloads and the methodology "Run on Endpoint" queries honour the same window.
         Lifetime / creation-date plots are not affected by the range selector — their x-axis is creation year, not snapshot date.
     </p>
 </details>


### PR DESCRIPTION
Closes #62.

When the `/trends` snapshot-range selector is active, the visible plots and CSV/PNG/SVG downloads already honour the range, but the methodology disclosure ("Run on Endpoint" / "Copy Query") still showed the full-range query iterating every `http://aopwiki.org/graph/YYYY-MM-DD` graph.

This adds `updateMethodologyQueries()` to `trends-range-selector.js`, called from `applyRange()` alongside the existing download-link sync — analogous to `updateMethodologyQueryUris()` on `/snapshot` (#43).

**Behaviour**
- Only **multi-graph** trend queries (`GRAPH ?graph { … } GROUP BY ?graph`) are rewritten. Graph IRIs sort lexicographically, so the bound `STR(?graph) >= "…/<start>" && STR(?graph) <= "…/<end>"` selects exactly the snapshots in the window.
  - If the query already has `FILTER(STRSTARTS(STR(?graph), "…/graph/"))`, the bound is appended to it.
  - Otherwise the `FILTER` is injected into the `GRAPH ?graph {` block (where `?graph` is in scope).
- Single-snapshot illustrative queries (`GRAPH <…/YYYY-MM-DD>`) are left untouched — a range doesn't apply.
- The pristine query is cached on first touch, so changing the window or resetting to full range always rewrites from the original rather than compounding edits.

**Acceptance check** — with Range 2022-01-01 → 2024-01-01, the rewritten query bounds `?graph` inclusively across the 9 quarterly snapshots in that window. Verified the augment / inject / single-graph-skip / reset-restore paths in isolation.

No JS test harness exists in this repo (Jest lives in the Snorql-UI repo); `node -c` syntax-checks clean.