### PR TITLE
docs: explain how to request a new plot (web + GitHub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,15 @@ Use the built-in monitoring endpoints:
 - `/health` - System health check
 - `/status` - Real-time monitoring dashboard
 
+## Requesting a New Plot
+
+You don't need to write any code to ask for a new visualization. Pick whichever route suits you — both create an issue from the same **New Plot Proposal** template:
+
+- **From the web (one click):** open a [pre-filled plot-request form](https://github.com/marvinm2/AOP-Wiki-RDF-dashboard/issues/new?template=new-plot.md). The dashboard's [About page](https://aopwiki-dashboard.vhp4safety.nl/about) links to the same form.
+- **On GitHub:** go to the [issue tracker](https://github.com/marvinm2/AOP-Wiki-RDF-dashboard/issues), click **New issue**, and choose **New Plot Proposal**.
+
+A GitHub account is required to submit. Describe the question the plot should answer, whether it's a latest-snapshot or historical-trend view, the RDF properties involved, and the chart type you'd expect — the more concrete, the faster it can be built.
+
 ## Contributing
 
 ### **Development Setup**

--- a/templates/about.html
+++ b/templates/about.html
@@ -89,6 +89,26 @@
     </div>
 
     <div class="about-section">
+        <h2>Requesting a New Plot</h2>
+        <p>Have a question about the AOP-Wiki that the current visualizations don't answer?
+           You can request a new plot in two ways &mdash; both land on the project's issue
+           tracker, where existing requests are also visible:</p>
+        <ul>
+            <li><strong>From the web (one click):</strong>
+                <a href="https://github.com/marvinm2/AOP-Wiki-RDF-dashboard/issues/new?template=new-plot.md"
+                   target="_blank" rel="noopener" class="about-link">open a pre-filled plot-request form</a>.
+                It prompts you for what the plot should show, whether it's a latest-snapshot
+                or historical-trend view, the RDF properties involved, and who benefits.</li>
+            <li><strong>On GitHub:</strong> go to the
+                <a href="https://github.com/marvinm2/AOP-Wiki-RDF-dashboard/issues"
+                   target="_blank" rel="noopener" class="about-link">issue tracker</a>,
+                click <em>New issue</em>, and choose the <em>New Plot Proposal</em> template.</li>
+        </ul>
+        <p>A GitHub account is needed to submit. The more concretely you describe the
+           question and the expected chart type, the faster it can be turned into a plot.</p>
+    </div>
+
+    <div class="about-section">
         <h2>Contact &amp; Feedback</h2>
         <p>Found a bug or have a feature request?
            <a href="https://github.com/marvinm2/AOP-Wiki-RDF-dashboard/issues"


### PR DESCRIPTION
Closes #88.

The repo already ships a `New Plot Proposal` issue template (`.github/ISSUE_TEMPLATE/new-plot.md`), but nothing on the dashboard or in the README told users it exists. This surfaces the request path via two routes:

- **From the web (one click):** a [pre-filled plot-request form](https://github.com/marvinm2/AOP-Wiki-RDF-dashboard/issues/new?template=new-plot.md) linked from the dashboard's **About** page.
- **On GitHub:** the manual *New issue → New Plot Proposal* route.

Changes:
- `templates/about.html` — new **Requesting a New Plot** section (above Contact & Feedback).
- `README.md` — matching **Requesting a New Plot** section before Contributing.

No code paths touched; reuses the existing issue template.