### PR TITLE
docs(plots): refresh inline descriptions after the plot-review fixes

### DIFF
--- a/static/js/coverage-toggle.js
+++ b/static/js/coverage-toggle.js
@@ -1,12 +1,12 @@
 /**
  * Coverage Analysis toggle controller.
  *
- * Drives the unified organ-coverage bar + pie via two segmented toggles:
+ * Drives the unified organ-coverage stacked bar + bucket-totals bar via two toggles:
  *   - scope: all | apical | ao
- *   - view:  absolute | percentage (bar only)
+ *   - view:  absolute | percentage (stacked bar only)
  *
- * Scope is shared between the bar and the pie so the user reads a single
- * coherent slice across the section. Version is read from the URL so the
+ * Scope is shared between both views so the user reads a single coherent
+ * slice across the section. Version is read from the URL so the
  * toggles play well with the version selector.
  */
 (function () {
@@ -122,7 +122,7 @@
                 currentScope = next;
                 toggleRoot.dataset.scope = next;
                 setActive(scopeButtons, currentScope, 'toggleScope');
-                // Bar and pie both follow scope.
+                // Both views follow scope.
                 fetchPlot(BAR_PLOT, currentScope, currentView);
                 fetchPlot(PIE_PLOT, currentScope, undefined);
             });

--- a/templates/latest.html
+++ b/templates/latest.html
@@ -308,9 +308,9 @@
                 <strong>A</strong> (curated UBERON/CL anatomy on Key Events),
                 <strong>A&prime;</strong> (UBERON/CL appearing as biological-event objects),
                 <strong>B</strong> (GO biological-process bridge, curated map), and
-                <strong>C</strong> (regex on AOP title — exploratory, grey). Bar and pie views share one
-                scope toggle so they stay in sync; the View toggle drives the bar only (pie slices are
-                inherently proportional).
+                <strong>C</strong> (regex on AOP title — exploratory, grey). Both views share one
+                scope toggle so they stay in sync; the View toggle (absolute/percentage) drives the
+                stacked bar only, while the bucket-totals bar always shows the AOP count per organ system.
                 <strong>Tip:</strong> the CSV download below contains <em>one row per AOP × bucket</em>
                 (columns: <code>AOP, AOP Title, AO URI, Organ System, Signals, Best Signal, Version, Scope</code>) —
                 including the "No annotation" bucket, which lists every AOP that the classifier could not place
@@ -354,7 +354,7 @@
                 </div>
                 <div class="coverage-pair-cell">
                     <div class="coverage-pair-cell-header">
-                        <h4>Pie view</h4>
+                        <h4>Bucket totals</h4>
                         <div class="download-dropdown">
                             <button class="download-button dropdown-toggle">Download &#x25BC;</button>
                             <div class="dropdown-menu">

--- a/templates/trends.html
+++ b/templates/trends.html
@@ -647,8 +647,9 @@
             </div>
         </div>
         <p class="plot-description">
-            Shows how densely connected the KE-KER graph is over time,
-            calculated as the ratio of edges to possible connections between nodes.
+            Mean per-AOP graph density over time — for each AOP, the ratio of its
+            Key Event Relationships to the maximum possible between its Key Events,
+            averaged across AOPs (those with fewer than 2 Key Events are excluded).
         </p>
         {{ methodology_note(methodology_notes, 'aop_network_density') }}
         <div class="lazy-plot" data-plot-name="aop_network_density">


### PR DESCRIPTION
Follow-up to #106. Updates the always-visible `plot-description` text (and one toggle-controller comment) that still described the old chart forms:

- **AOP Network Density** description now states the mean per-AOP density model instead of the old global 'ratio of edges to possible connections between nodes' framing. (The y-axis and Methodology panel were already correct; only this inline blurb was stale.)
- **Organ coverage** second view relabeled 'Pie view' -> 'Bucket totals' and its description/JS comments updated, since #105 converted that pie to a sorted bar.

Template + JS only; no plot code, queries, or cache keys touched.