### PR TITLE
fix(plots): avg-per-AOP counts memberships (real ~6.3 KEs/AOP); tidy download filenames

### DIFF
--- a/app.py
+++ b/app.py
@@ -1300,6 +1300,10 @@ def download_latest_generic(plot_name):
     if cache_key not in _plot_data_cache:
         cache_key = plot_name
 
+    # Filename uses the clean base name (not the resolved cache key), so the
+    # version_key suffix doesn't leak in as a doubled "-latest".
+    filename_base = f'latest_{plot_name}'
+
     try:
         if export_format == 'csv':
             csv_data = get_csv_with_metadata(cache_key, include_metadata)
@@ -1309,7 +1313,7 @@ def download_latest_generic(plot_name):
             return Response(
                 csv_data,
                 mimetype='text/csv',
-                headers={'Content-Disposition': f'attachment; filename={build_export_filename(cache_key, "csv", version)}'}
+                headers={'Content-Disposition': f'attachment; filename={build_export_filename(filename_base, "csv", version)}'}
             )
 
         elif export_format in ['png', 'svg']:
@@ -1321,7 +1325,7 @@ def download_latest_generic(plot_name):
             return Response(
                 image_bytes,
                 mimetype=mimetype,
-                headers={'Content-Disposition': f'attachment; filename={build_export_filename(cache_key, export_format, version)}'}
+                headers={'Content-Disposition': f'attachment; filename={build_export_filename(filename_base, export_format, version)}'}
             )
 
         else:

--- a/plots/latest_plots.py
+++ b/plots/latest_plots.py
@@ -520,11 +520,14 @@ def plot_latest_avg_per_aop(version: str = None) -> str:
         GROUP BY ?graph
         {order_limit}
     """
+    # Count AOP-KE / AOP-KER MEMBERSHIPS (not distinct KE/KER entities): Key Events
+    # are reused across AOPs, so distinct-entity counts understate the per-AOP average.
     query_kes = f"""
         SELECT ?graph (COUNT(?ke) AS ?count)
         WHERE {{
             GRAPH ?graph {{
-                ?ke a aopo:KeyEvent .
+                ?aop a aopo:AdverseOutcomePathway ;
+                     aopo:has_key_event ?ke .
             }}
             FILTER(STRSTARTS(STR(?graph), "http://aopwiki.org/graph/"))
             {where_filter}
@@ -536,7 +539,8 @@ def plot_latest_avg_per_aop(version: str = None) -> str:
         SELECT ?graph (COUNT(?ker) AS ?count)
         WHERE {{
             GRAPH ?graph {{
-                ?ker a aopo:KeyEventRelationship .
+                ?aop a aopo:AdverseOutcomePathway ;
+                     aopo:has_key_event_relationship ?ker .
             }}
             FILTER(STRSTARTS(STR(?graph), "http://aopwiki.org/graph/"))
             {where_filter}

--- a/plots/trends_plots.py
+++ b/plots/trends_plots.py
@@ -1048,11 +1048,17 @@ def plot_avg_per_aop() -> tuple[str, str]:
             }
             GROUP BY ?graph
         """
+        # Count has_key_event / has_key_event_relationship MEMBERSHIPS (one row per
+        # AOP-KE / AOP-KER link), not distinct KE/KER entities. Averaging distinct
+        # entities graph-wide understates the metric because Key Events are reused
+        # across AOPs (e.g. 1583 distinct KEs / 588 AOPs = 2.7, whereas the average
+        # AOP actually contains ~6 KEs).
         query_kes = """
             SELECT ?graph (COUNT(?ke) AS ?count)
             WHERE {
                 GRAPH ?graph {
-                    ?ke a aopo:KeyEvent .
+                    ?aop a aopo:AdverseOutcomePathway ;
+                         aopo:has_key_event ?ke .
                 }
                 FILTER(STRSTARTS(STR(?graph), "http://aopwiki.org/graph/"))
             }
@@ -1062,7 +1068,8 @@ def plot_avg_per_aop() -> tuple[str, str]:
             SELECT ?graph (COUNT(?ker) AS ?count)
             WHERE {
                 GRAPH ?graph {
-                    ?ker a aopo:KeyEventRelationship .
+                    ?aop a aopo:AdverseOutcomePathway ;
+                         aopo:has_key_event_relationship ?ker .
                 }
                 FILTER(STRSTARTS(STR(?graph), "http://aopwiki.org/graph/"))
             }

--- a/static/data/methodology_notes.json
+++ b/static/data/methodology_notes.json
@@ -33,12 +33,12 @@
                 "query": "SELECT ?graph (COUNT(?aop) AS ?count)\nWHERE {\n  GRAPH ?graph { ?aop a aopo:AdverseOutcomePathway . }\n  FILTER(STRSTARTS(STR(?graph), \"http://aopwiki.org/graph/\"))\n}\nGROUP BY ?graph\nORDER BY DESC(?graph) LIMIT 1"
             },
             {
-                "caption": "Count Key Events in latest graph",
-                "query": "SELECT ?graph (COUNT(?ke) AS ?count)\nWHERE {\n  GRAPH ?graph { ?ke a aopo:KeyEvent . }\n  FILTER(STRSTARTS(STR(?graph), \"http://aopwiki.org/graph/\"))\n}\nGROUP BY ?graph\nORDER BY DESC(?graph) LIMIT 1"
+                "caption": "Count AOP-Key Event memberships in latest graph (numerator; Key Events reused across AOPs are counted once per AOP)",
+                "query": "SELECT ?graph (COUNT(?ke) AS ?count)\nWHERE {\n  GRAPH ?graph { ?aop a aopo:AdverseOutcomePathway ; aopo:has_key_event ?ke . }\n  FILTER(STRSTARTS(STR(?graph), \"http://aopwiki.org/graph/\"))\n}\nGROUP BY ?graph\nORDER BY DESC(?graph) LIMIT 1"
             },
             {
-                "caption": "Count Key Event Relationships in latest graph",
-                "query": "SELECT ?graph (COUNT(?ker) AS ?count)\nWHERE {\n  GRAPH ?graph { ?ker a aopo:KeyEventRelationship . }\n  FILTER(STRSTARTS(STR(?graph), \"http://aopwiki.org/graph/\"))\n}\nGROUP BY ?graph\nORDER BY DESC(?graph) LIMIT 1"
+                "caption": "Count AOP-Key Event Relationship memberships in latest graph",
+                "query": "SELECT ?graph (COUNT(?ker) AS ?count)\nWHERE {\n  GRAPH ?graph { ?aop a aopo:AdverseOutcomePathway ; aopo:has_key_event_relationship ?ker . }\n  FILTER(STRSTARTS(STR(?graph), \"http://aopwiki.org/graph/\"))\n}\nGROUP BY ?graph\nORDER BY DESC(?graph) LIMIT 1"
             }
         ]
     },
@@ -404,9 +404,22 @@
     "average_components_per_aop": {
         "title": "Average KEs and KERs per AOP Over Time",
         "description": "Tracks how densely connected each AOP is on average over time, measured by the number of Key Events and Key Event Relationships per AOP in each version. Indicates whether newer AOPs tend to be more or less complex.",
-        "data_source": "SPARQL queries count total AOP, KE-to-AOP, and KER-to-AOP relationships across all versions, then compute the ratio per version.",
+        "data_source": "Three SPARQL queries per version count AOPs, AOP-Key Event memberships, and AOP-Key Event Relationship memberships; the plot divides each membership count by the AOP count. Memberships (not distinct KE/KER entities) are counted so that Key Events reused across AOPs are counted once per AOP, giving the true per-AOP average.",
         "limitations": "Averages can be dominated by a few very large or very small AOPs. Does not distinguish between well-developed and stub AOPs. Only counts explicitly declared relationships. Trend data covers only the published RDF release versions available in the SPARQL endpoint; the AOP-Wiki knowledge base predates the earliest RDF release, so earlier activity is not captured.",
-        "sparql": "SELECT ?graph\n  (COUNT(DISTINCT ?aop) AS ?aop_count)\n  (COUNT(?ke) AS ?ke_count)\n  (COUNT(?ker) AS ?ker_count)\nWHERE {\n  GRAPH ?graph {\n    ?aop a aopo:AdverseOutcomePathway .\n    OPTIONAL { ?aop aopo:has_key_event ?ke . }\n    OPTIONAL { ?aop aopo:has_key_event_relationship ?ker . }\n  }\n}\nGROUP BY ?graph\nORDER BY ?graph"
+        "queries": [
+            {
+                "caption": "Count AOPs per version (denominator)",
+                "query": "SELECT ?graph (COUNT(?aop) AS ?count)\nWHERE {\n  GRAPH ?graph { ?aop a aopo:AdverseOutcomePathway . }\n  FILTER(STRSTARTS(STR(?graph), \"http://aopwiki.org/graph/\"))\n}\nGROUP BY ?graph"
+            },
+            {
+                "caption": "Count AOP-Key Event memberships per version (numerator for avg KEs/AOP)",
+                "query": "SELECT ?graph (COUNT(?ke) AS ?count)\nWHERE {\n  GRAPH ?graph { ?aop a aopo:AdverseOutcomePathway ; aopo:has_key_event ?ke . }\n  FILTER(STRSTARTS(STR(?graph), \"http://aopwiki.org/graph/\"))\n}\nGROUP BY ?graph"
+            },
+            {
+                "caption": "Count AOP-Key Event Relationship memberships per version (numerator for avg KERs/AOP)",
+                "query": "SELECT ?graph (COUNT(?ker) AS ?count)\nWHERE {\n  GRAPH ?graph { ?aop a aopo:AdverseOutcomePathway ; aopo:has_key_event_relationship ?ker . }\n  FILTER(STRSTARTS(STR(?graph), \"http://aopwiki.org/graph/\"))\n}\nGROUP BY ?graph"
+            }
+        ]
     },
     "aop_network_density": {
         "title": "AOP Network Density Over Time",


### PR DESCRIPTION
Two small fixes from review follow-up.

**Average components per AOP** — `plot_avg_per_aop` and `plot_latest_avg_per_aop` counted *distinct* KE/KER entities graph-wide and divided by AOPs. Because Key Events are reused across AOPs, that understated the metric (1583 KEs / 588 AOPs = 2.7). Now counts `has_key_event` / `has_key_event_relationship` **memberships** per AOP → **~6.3 KEs and ~5.6 KERs per AOP** (2026-07-01), matching the intuitive 'how many KEs does an AOP have'. Methodology disclosed queries + prose updated to match (they already described the membership approach).

**Download filenames** — `/download/latest/<name>` built the filename from the resolved cache key, leaking the version_key as a doubled '-latest' (`latest-ke-reuse-latest_....csv`). Now uses the clean base name (`latest-ke-reuse_....csv`). CSV and images already share the descriptive `<plot>_<date>.<ext>` scheme.

Cache keys/routes unchanged.