### PR TITLE
docs(citation): add software concept DOI badge

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,5 +44,8 @@ preferred-citation:
   url: https://doi.org/10.1089/aivt.2021.0010
 identifiers:
   - type: doi
+    value: "10.5281/zenodo.21384259"
+    description: "Concept DOI for this dashboard software (all versions)."
+  - type: doi
     value: "10.5281/zenodo.13353286"
     description: "Concept DOI for the AOP-Wiki RDF dataset visualised by this dashboard."

--- a/README.md
+++ b/README.md
@@ -286,9 +286,12 @@ For questions, bug reports, and feature requests please open a [GitHub Issue](ht
 
 ## Citation
 
-If you use this dashboard, please cite the underlying AOP-Wiki RDF paper and the dataset DOI. See [`CITATION.cff`](CITATION.cff).
+If you use this dashboard, please cite the underlying AOP-Wiki RDF paper, the software, and the dataset DOI. See [`CITATION.cff`](CITATION.cff).
+
+[![Software DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21384259.svg)](https://doi.org/10.5281/zenodo.21384259)
 
 - Paper: Martens M., Evelo C.T., Willighagen E.L. (2022). *Providing Adverse Outcome Pathways from the AOP-Wiki in a Semantic Web Format to Increase Usability and Accessibility of the Content.* Applied In Vitro Toxicology 8(1):2–13. [doi:10.1089/aivt.2021.0010](https://doi.org/10.1089/aivt.2021.0010)
+- Software (this dashboard, concept DOI): [10.5281/zenodo.21384259](https://doi.org/10.5281/zenodo.21384259)
 - Dataset releases (concept DOI): [10.5281/zenodo.13353286](https://doi.org/10.5281/zenodo.13353286)
 
 ## Support


### PR DESCRIPTION
Adds the minted Zenodo software concept DOI (10.5281/zenodo.21384259) as a badge + citation bullet in the README and an identifier in CITATION.cff. Closes the last box of #89.