### PR TITLE
docs(zenodo): scope dashboard funding to VHP4Safety only

### DIFF
--- a/.github/workflows/upload-plots-zenodo.yml
+++ b/.github/workflows/upload-plots-zenodo.yml
@@ -113,7 +113,7 @@ jobs:
             --argjson creators '[{"name": "Martens, Marvin", "affiliation": "Department of Translational Genomics, Maastricht University, Maastricht, the Netherlands", "orcid": "0000-0003-2230-0840"}, {"name": "Willighagen, Egon", "affiliation": "Department of Translational Genomics, Maastricht University, Maastricht, the Netherlands", "orcid": "0000-0001-7542-0286"}]' \
             --argjson related_identifiers '[{"identifier": "10.1089/aivt.2021.0010", "relation": "isDocumentedBy", "resource_type": "publication-article", "scheme": "doi"}, {"identifier": "10.5281/zenodo.13353286", "relation": "isDerivedFrom", "scheme": "doi"}]' \
             --argjson communities '[{"identifier": "vhp4safety"}]' \
-            --arg notes "Plots and data derived from the AOP-Wiki (CC-BY-SA 4.0). Funded in part by EU Horizon 2020 (NanoSolveIT 814572, RiskGONE 814425) and VHP4Safety (NWO NWA-ORC 1292.19.272)." \
+            --arg notes "Plots and data derived from the AOP-Wiki (CC-BY-SA 4.0). Developed within VHP4Safety, funded by the Netherlands Research Council (NWO) NWA-ORC 1292.19.272." \
             '{ metadata: {
                  title: $title, version: $version, publication_date: $date,
                  description: $description, access_right: "open",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -17,9 +17,7 @@
     {"identifier": "10.5281/zenodo.13353286", "relation": "isSupplementTo", "scheme": "doi"}
   ],
   "grants": [
-    {"id": "10.13039/501100000780::814572"},
-    {"id": "10.13039/501100000780::814425"},
     {"id": "10.13039/501100003246::36952"}
   ],
-  "notes": "Funded by the European Union's Horizon 2020 program (NanoSolveIT no. 814572, RiskGONE no. 814425) and VHP4Safety, funded by the Netherlands Research Council (NWO) NWA-ORC 1292.19.272."
+  "notes": "Developed within VHP4Safety, funded by the Netherlands Research Council (NWO) NWA-ORC 1292.19.272."
 }


### PR DESCRIPTION
The dashboard .zenodo.json listed NanoSolveIT (814572) and RiskGONE (814425) Horizon 2020 grants; those fund the upstream AOP-Wiki RDF dataset, not this dashboard. The dashboard is a VHP4Safety deliverable (NWO NWA-ORC 1292.19.272), which is what its own footer and About page already state. Keeps only the VHP4Safety grant and updates the notes.