### PR TITLE
feat(latest): Most-Reused Ontology Terms plot (#27)

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,6 +114,7 @@ from plots import (
     plot_latest_entity_by_oecd_status,
     plot_latest_ke_reuse,
     plot_latest_ke_reuse_distribution,
+    plot_latest_top_ontology_terms,
     plot_latest_ontology_diversity,
     plot_latest_aop_completeness_unique_colors,
     plot_latest_organ_coverage,
@@ -1537,7 +1538,7 @@ def download_bulk():
                 'latest_aop_completeness', 'latest_ke_annotation_depth',
                 'latest_ke_by_bio_level', 'latest_taxonomic_groups',
                 'latest_entity_by_oecd_status', 'latest_ke_reuse',
-                'latest_ke_reuse_distribution'
+                'latest_ke_reuse_distribution', 'latest_top_ontology_terms'
             ],
             'database-state': ['latest_entity_counts'],
             'network-analysis': ['latest_aop_connectivity', 'latest_avg_per_aop'],
@@ -1876,6 +1877,7 @@ def get_plot(plot_name):
         'latest_entity_by_oecd_status': plot_latest_entity_by_oecd_status,
         'latest_ke_reuse': plot_latest_ke_reuse,
         'latest_ke_reuse_distribution': plot_latest_ke_reuse_distribution,
+        'latest_top_ontology_terms': plot_latest_top_ontology_terms,
         'latest_ontology_diversity': plot_latest_ontology_diversity,
         'latest_aop_completeness_unique': plot_latest_aop_completeness_unique_colors,
         'latest_organ_coverage': plot_latest_organ_coverage,

--- a/plots/__init__.py
+++ b/plots/__init__.py
@@ -218,6 +218,7 @@ from .latest_plots import (
     plot_latest_taxonomic_groups,
     plot_latest_entity_by_oecd_status,
     plot_latest_ke_reuse,
+    plot_latest_top_ontology_terms,
     plot_latest_ke_reuse_distribution,
 
     # Data quality & diversity (Phase 04-03)
@@ -313,6 +314,7 @@ __all__ = [
     'plot_latest_taxonomic_groups',
     'plot_latest_entity_by_oecd_status',
     'plot_latest_ke_reuse',
+    'plot_latest_top_ontology_terms',
     'plot_latest_ke_reuse_distribution',
     'plot_latest_ontology_diversity',
     'plot_latest_organ_coverage',
@@ -387,6 +389,7 @@ def get_available_functions():
             'plot_latest_taxonomic_groups',
             'plot_latest_entity_by_oecd_status',
             'plot_latest_ke_reuse',
+            'plot_latest_top_ontology_terms',
             'plot_latest_ke_reuse_distribution',
             'plot_latest_ontology_diversity',
             'plot_latest_organ_coverage',

--- a/plots/latest_plots.py
+++ b/plots/latest_plots.py
@@ -1879,6 +1879,137 @@ def plot_latest_ke_reuse(version: str = None) -> str:
     return render_plot_html(fig)
 
 
+def _ontology_curie(iri: str):
+    """Best-effort compact CURIE + source prefix for an ontology term IRI.
+
+    Returns (curie, prefix), e.g. GO_0023052 -> ("GO:0023052", "GO"),
+    mesh/D006965 -> ("MeSH:D006965", "MESH"). Falls back to the IRI's last
+    segment when the pattern is unknown.
+    """
+    if "/obo/" in iri:
+        frag = iri.rsplit("/", 1)[-1]          # e.g. GO_0023052
+        if "_" in frag:
+            prefix, _, local = frag.partition("_")
+            return f"{prefix}:{local}", prefix.upper()
+        return frag, ""
+    if "/mesh/" in iri:
+        return f"MeSH:{iri.rsplit('/', 1)[-1]}", "MESH"
+    frag = iri.rsplit("#", 1)[-1].rsplit("/", 1)[-1]
+    return frag, ""
+
+
+def plot_latest_top_ontology_terms(version: str = None) -> str:
+    """Show the individual ontology terms most reused across Key Events (top 30).
+
+    Counts how many distinct Key Events reference each ontology term through any
+    biological-event slot (Process/Object/Action), labelled by dc:title and
+    coloured by ontology source (GO, CHEBI, PATO, MeSH, ...).
+
+    Args:
+        version: Optional version string. If None, uses latest.
+
+    Returns:
+        str: Plotly HTML string for embedding.
+    """
+    global _plot_data_cache
+
+    # Determine target graph
+    if version:
+        target_graph = f"http://aopwiki.org/graph/{version}"
+        latest_version = version
+    else:
+        version_query = """
+        SELECT ?graph
+        WHERE {
+            GRAPH ?graph { ?s a aopo:AdverseOutcomePathway . }
+            FILTER(STRSTARTS(STR(?graph), "http://aopwiki.org/graph/"))
+        }
+        GROUP BY ?graph
+        ORDER BY DESC(?graph)
+        LIMIT 1
+        """
+        version_results = run_sparql_query(version_query)
+        if not version_results:
+            return create_fallback_plot("Most Reused Ontology Terms", "No graphs available")
+        target_graph = version_results[0]["graph"]["value"]
+        latest_version = target_graph.split("/")[-1]
+
+    query = f"""
+    SELECT ?term (SAMPLE(?title_val) AS ?label) (SAMPLE(?source_val) AS ?source) (COUNT(DISTINCT ?ke) AS ?ke_count)
+    WHERE {{
+      GRAPH <{target_graph}> {{
+        ?ke a aopo:KeyEvent ;
+            aopo:hasBiologicalEvent ?be .
+        ?be aopo:hasProcess|aopo:hasObject|aopo:hasAction ?term .
+        OPTIONAL {{ ?term dc:title ?title_val . }}
+        OPTIONAL {{ ?term dc:source ?source_val . }}
+      }}
+      FILTER(isIRI(?term))
+    }}
+    GROUP BY ?term
+    ORDER BY DESC(?ke_count)
+    LIMIT 30
+    """
+
+    results = run_sparql_query(query)
+    if not results:
+        return create_fallback_plot("Most Reused Ontology Terms", "No ontology terms found")
+
+    data = []
+    for r in results:
+        term_uri = r["term"]["value"]
+        curie, derived_source = _ontology_curie(term_uri)
+        source = r.get("source", {}).get("value") or derived_source or "Other"
+        title = r.get("label", {}).get("value", "").strip()
+        ke_count = int(r["ke_count"]["value"])
+        data.append({
+            "Term": title if title else curie,
+            "CURIE": curie,
+            "Source": source,
+            "KE Count": ke_count,
+            "term_url": term_uri,
+        })
+
+    if not data:
+        return create_fallback_plot("Most Reused Ontology Terms", "No ontology term reuse data found")
+
+    df = pd.DataFrame(data)
+    # Disambiguate any duplicate display labels by appending the CURIE
+    dup = df["Term"].duplicated(keep=False)
+    df.loc[dup, "Term"] = df.loc[dup, "Term"] + " (" + df.loc[dup, "CURIE"] + ")"
+    df = df.sort_values("KE Count", ascending=True)
+    version_key = version or "latest"
+    df["Version"] = latest_version
+    _plot_data_cache[f'latest_top_ontology_terms_{version_key}'] = df
+
+    # Stable colour per ontology source
+    sources = sorted(df["Source"].unique())
+    palette = BRAND_COLORS['palette']
+    color_map = {s: palette[i % len(palette)] for i, s in enumerate(sources)}
+
+    fig = px.bar(
+        df,
+        x="KE Count",
+        y="Term",
+        color="Source",
+        orientation='h',
+        text="KE Count",
+        custom_data=['term_url', 'CURIE'],
+        color_discrete_map=color_map,
+    )
+    fig.update_traces(textposition='outside')
+    fig.update_layout(
+        height=max(400, len(df) * 26 + 120),
+        margin=dict(l=320, r=30, t=60, b=60),
+        yaxis=dict(title="", categoryorder="total ascending"),
+        xaxis=dict(title="Number of Key Events"),
+        legend=dict(title="Ontology"),
+    )
+
+    _plot_figure_cache[f'latest_top_ontology_terms_{version_key}'] = fig
+    return render_plot_html(fig)
+
+
 def plot_latest_ke_reuse_distribution(version: str = None) -> str:
     """Show the distribution of how many AOPs each KE belongs to (reuse histogram).
 

--- a/static/data/methodology_notes.json
+++ b/static/data/methodology_notes.json
@@ -581,6 +581,22 @@
             }
         ]
     },
+    "latest_top_ontology_terms": {
+        "title": "Most-Reused Ontology Terms",
+        "description": "Top 30 individual ontology terms referenced by the most Key Events, across all biological-event slots (process, object, action). Bars are labelled by the term's dc:title and coloured by ontology source (GO, CHEBI, PATO, MeSH, ...), revealing which specific biological concepts recur across the AOP-Wiki.",
+        "data_source": "SPARQL query counts distinct Key Events per ontology term reached via aopo:hasBiologicalEvent and any of aopo:hasProcess / aopo:hasObject / aopo:hasAction. Human-readable labels come from dc:title and the ontology source from dc:source on each term.",
+        "limitations": "Limited to the top 30 terms. A term is counted once per Key Event regardless of slot. Terms lacking a dc:title are shown as a CURIE (e.g. GO:0023052); sources without dc:source are derived from the IRI prefix or labelled 'Other'. Counts reflect explicit biological-event annotations in the RDF data.",
+        "queries": [
+            {
+                "caption": "Identify latest graph (AOP anchor)",
+                "query": "SELECT ?graph\nWHERE {\n  GRAPH ?graph { ?s a aopo:AdverseOutcomePathway . }\n  FILTER(STRSTARTS(STR(?graph), \"http://aopwiki.org/graph/\"))\n}\nGROUP BY ?graph\nORDER BY DESC(?graph)\nLIMIT 1"
+            },
+            {
+                "caption": "Top 30 ontology terms by distinct-KE count (all biological-event slots)",
+                "query": "SELECT ?term (SAMPLE(?title_val) AS ?label) (SAMPLE(?source_val) AS ?source) (COUNT(DISTINCT ?ke) AS ?ke_count)\nWHERE {\n  GRAPH __GRAPH_URI__ {\n    ?ke a aopo:KeyEvent ;\n        aopo:hasBiologicalEvent ?be .\n    ?be aopo:hasProcess|aopo:hasObject|aopo:hasAction ?term .\n    OPTIONAL { ?term dc:title ?title_val . }\n    OPTIONAL { ?term dc:source ?source_val . }\n  }\n  FILTER(isIRI(?term))\n}\nGROUP BY ?term\nORDER BY DESC(?ke_count)\nLIMIT 30"
+            }
+        ]
+    },
     "ontology_term_growth": {
         "title": "Ontology Term Growth Over Time",
         "description": "Tracks the number of unique ontology terms used in biological process and object annotations across database versions. Growth indicates expanding annotation vocabulary and richer biological characterization.",

--- a/static/js/version-selector.js
+++ b/static/js/version-selector.js
@@ -29,6 +29,7 @@
         'latest_entity_by_oecd_status',
         'latest_ke_reuse',
         'latest_ke_reuse_distribution',
+        'latest_top_ontology_terms',
         'latest_ontology_diversity',
         'latest_organ_coverage_unified',
         'latest_organ_coverage_pie',

--- a/templates/latest.html
+++ b/templates/latest.html
@@ -520,6 +520,28 @@
         </div>
         <div class="plot-box">
             <div class="plot-header">
+                <h3>Most-Reused Ontology Terms</h3>
+                <div class="download-dropdown">
+                    <button class="download-button dropdown-toggle">Download &#x25BC;</button>
+                    <div class="dropdown-menu">
+                        <a href="/download/latest/top_ontology_terms?format=csv" class="dropdown-item">CSV</a>
+                        <a href="/download/latest/top_ontology_terms?format=png" class="dropdown-item">PNG</a>
+                        <a href="/download/latest/top_ontology_terms?format=svg" class="dropdown-item">SVG</a>
+                    </div>
+                </div>
+            </div>
+            <p class="plot-description">
+                Top 30 individual ontology terms referenced by the most Key Events, across all biological-event
+                slots (process, object, action), coloured by ontology source (GO, CHEBI, PATO, MeSH, ...).
+            </p>
+            {{ methodology_note(methodology_notes, 'latest_top_ontology_terms') }}
+            <div class="lazy-plot" data-plot-name="latest_top_ontology_terms">
+                <!-- Plot will be loaded here via JavaScript -->
+            </div>
+            {{ data_table_toggle('latest_top_ontology_terms') }}
+        </div>
+        <div class="plot-box">
+            <div class="plot-header">
                 <h3>Ontology Usage</h3>
                 <div class="download-dropdown">
                     <button class="download-button dropdown-toggle">Download &#x25BC;</button>

--- a/tests/test_all_downloads.py
+++ b/tests/test_all_downloads.py
@@ -70,6 +70,7 @@ LATEST_PLOTS = [
     "latest_entity_by_oecd_status",
     "latest_ke_reuse",
     "latest_ke_reuse_distribution",
+    "latest_top_ontology_terms",
     "latest_ontology_diversity",
     "latest_aop_completeness_unique",
     "latest_organ_coverage",
@@ -270,7 +271,7 @@ def run_audit(client, *, latest: str, historical: str,
     #    route the template actually uses for them.
     for plot in ("latest_ke_by_bio_level", "latest_taxonomic_groups",
                  "latest_entity_by_oecd_status", "latest_ke_reuse",
-                 "latest_ke_reuse_distribution"):
+                 "latest_ke_reuse_distribution", "latest_top_ontology_terms"):
         suffix = plot[len("latest_"):]
         client.get(f"/api/plot/{plot}?version={latest}")
         report.add(_check(client,


### PR DESCRIPTION
Adds the individual-term reuse view #27 asked for. The existing ontology plots only bucket terms **by source** (GO/CHEBI/…); this new snapshot plot shows the **top 30 individual terms** by how many distinct Key Events reference them, across all biological-event slots (process/object/action).

- **Labels + colour**: term names come from `dc:title` (e.g. `GO_0023052` → "signaling"), coloured by `dc:source`. Terms without a title fall back to a CURIE. Verified live: top terms are signaling (GO, 40 KEs), gene expression (GO, 38), cell proliferation (GO, 17).
- **Reuses** the `plot_latest_ke_reuse` pattern (horizontal sorted bar, version-suffixed data/figure caches, generic `/download/latest/<suffix>` route).
- **Wiring**: `plots/__init__.py`, `app.py` dispatch + bulk categories, `templates/latest.html` (placed by the ontology plots), `version-selector.js`, a `methodology_notes.json` entry with both disclosed SPARQL queries, and a `test_all_downloads.py` entry.
- **Verified**: plot renders valid Plotly HTML with correct cached data; `methodology-lint` passes (0 findings, entry counted).

Closes #27.