### PR TITLE
feat(latest): Top AOP Contributors plot (#29)

### DIFF
--- a/app.py
+++ b/app.py
@@ -115,6 +115,7 @@ from plots import (
     plot_latest_ke_reuse,
     plot_latest_ke_reuse_distribution,
     plot_latest_top_ontology_terms,
+    plot_latest_author_contributions,
     plot_latest_ontology_diversity,
     plot_latest_aop_completeness_unique_colors,
     plot_latest_organ_coverage,
@@ -1538,7 +1539,8 @@ def download_bulk():
                 'latest_aop_completeness', 'latest_ke_annotation_depth',
                 'latest_ke_by_bio_level', 'latest_taxonomic_groups',
                 'latest_entity_by_oecd_status', 'latest_ke_reuse',
-                'latest_ke_reuse_distribution', 'latest_top_ontology_terms'
+                'latest_ke_reuse_distribution', 'latest_top_ontology_terms',
+                'latest_author_contributions'
             ],
             'database-state': ['latest_entity_counts'],
             'network-analysis': ['latest_aop_connectivity', 'latest_avg_per_aop'],
@@ -1878,6 +1880,7 @@ def get_plot(plot_name):
         'latest_ke_reuse': plot_latest_ke_reuse,
         'latest_ke_reuse_distribution': plot_latest_ke_reuse_distribution,
         'latest_top_ontology_terms': plot_latest_top_ontology_terms,
+        'latest_author_contributions': plot_latest_author_contributions,
         'latest_ontology_diversity': plot_latest_ontology_diversity,
         'latest_aop_completeness_unique': plot_latest_aop_completeness_unique_colors,
         'latest_organ_coverage': plot_latest_organ_coverage,

--- a/plots/__init__.py
+++ b/plots/__init__.py
@@ -219,6 +219,7 @@ from .latest_plots import (
     plot_latest_entity_by_oecd_status,
     plot_latest_ke_reuse,
     plot_latest_top_ontology_terms,
+    plot_latest_author_contributions,
     plot_latest_ke_reuse_distribution,
 
     # Data quality & diversity (Phase 04-03)
@@ -315,6 +316,7 @@ __all__ = [
     'plot_latest_entity_by_oecd_status',
     'plot_latest_ke_reuse',
     'plot_latest_top_ontology_terms',
+    'plot_latest_author_contributions',
     'plot_latest_ke_reuse_distribution',
     'plot_latest_ontology_diversity',
     'plot_latest_organ_coverage',
@@ -390,6 +392,7 @@ def get_available_functions():
             'plot_latest_entity_by_oecd_status',
             'plot_latest_ke_reuse',
             'plot_latest_top_ontology_terms',
+            'plot_latest_author_contributions',
             'plot_latest_ke_reuse_distribution',
             'plot_latest_ontology_diversity',
             'plot_latest_organ_coverage',

--- a/plots/latest_plots.py
+++ b/plots/latest_plots.py
@@ -55,6 +55,7 @@ Author:
     Marvin Martens
 """
 
+import html
 import json
 import os
 import re
@@ -2007,6 +2008,117 @@ def plot_latest_top_ontology_terms(version: str = None) -> str:
     )
 
     _plot_figure_cache[f'latest_top_ontology_terms_{version_key}'] = fig
+    return render_plot_html(fig)
+
+
+def _clean_author_label(raw: str) -> str:
+    """Best-effort tidy of a free-text dc:creator string for display.
+
+    Creator values in the AOP-Wiki are free text (names, workgroups, sometimes
+    with HTML entities or embedded affiliations), so strip tags/entities and
+    collapse whitespace.
+    """
+    s = html.unescape(raw or "")
+    s = re.sub(r"<[^>]+>", " ", s)     # strip HTML tags
+    s = s.replace("\xa0", " ")
+    s = re.sub(r"\s+", " ", s).strip()
+    return s
+
+
+def plot_latest_author_contributions(version: str = None) -> str:
+    """Show the most prolific AOP contributors (top 20 by AOP count).
+
+    Counts distinct AOPs per dc:creator. Creator strings are free text, so
+    labels are cleaned (HTML stripped, whitespace collapsed) and truncated.
+
+    Args:
+        version: Optional version string. If None, uses latest.
+
+    Returns:
+        str: Plotly HTML string for embedding.
+    """
+    global _plot_data_cache
+
+    # Determine target graph
+    if version:
+        target_graph = f"http://aopwiki.org/graph/{version}"
+        latest_version = version
+    else:
+        version_query = """
+        SELECT ?graph
+        WHERE {
+            GRAPH ?graph { ?s a aopo:AdverseOutcomePathway . }
+            FILTER(STRSTARTS(STR(?graph), "http://aopwiki.org/graph/"))
+        }
+        GROUP BY ?graph
+        ORDER BY DESC(?graph)
+        LIMIT 1
+        """
+        version_results = run_sparql_query(version_query)
+        if not version_results:
+            return create_fallback_plot("Top AOP Contributors", "No graphs available")
+        target_graph = version_results[0]["graph"]["value"]
+        latest_version = target_graph.split("/")[-1]
+
+    query = f"""
+    SELECT ?creator (COUNT(DISTINCT ?aop) AS ?aop_count)
+    WHERE {{
+      GRAPH <{target_graph}> {{
+        ?aop a aopo:AdverseOutcomePathway ;
+             dc:creator ?creator .
+      }}
+    }}
+    GROUP BY ?creator
+    ORDER BY DESC(?aop_count)
+    LIMIT 20
+    """
+
+    results = run_sparql_query(query)
+    if not results:
+        return create_fallback_plot("Top AOP Contributors", "No author data found")
+
+    data = []
+    for r in results:
+        label = _clean_author_label(r["creator"]["value"])
+        if not label:
+            continue
+        aop_count = int(r["aop_count"]["value"])
+        display = label[:55] + "…" if len(label) > 55 else label
+        data.append({
+            "Contributor": display,
+            "Full name": label,
+            "AOP Count": aop_count,
+        })
+
+    if not data:
+        return create_fallback_plot("Top AOP Contributors", "No author data found")
+
+    df = pd.DataFrame(data)
+    # Disambiguate any duplicate truncated labels with a longer form
+    dup = df["Contributor"].duplicated(keep=False)
+    df.loc[dup, "Contributor"] = df.loc[dup, "Full name"].str[:70]
+    df = df.sort_values("AOP Count", ascending=True)
+    version_key = version or "latest"
+    df["Version"] = latest_version
+    _plot_data_cache[f'latest_author_contributions_{version_key}'] = df
+
+    fig = px.bar(
+        df,
+        x="AOP Count",
+        y="Contributor",
+        orientation='h',
+        text="AOP Count",
+    )
+    fig.update_traces(marker_color=BRAND_COLORS['blue'], textposition='outside')
+    fig.update_layout(
+        showlegend=False,
+        height=max(400, len(df) * 28 + 120),
+        margin=dict(l=340, r=40, t=60, b=60),
+        yaxis=dict(title="", categoryorder="total ascending"),
+        xaxis=dict(title="Number of AOPs authored"),
+    )
+
+    _plot_figure_cache[f'latest_author_contributions_{version_key}'] = fig
     return render_plot_html(fig)
 
 

--- a/static/data/methodology_notes.json
+++ b/static/data/methodology_notes.json
@@ -597,6 +597,22 @@
             }
         ]
     },
+    "latest_author_contributions": {
+        "title": "Top AOP Contributors",
+        "description": "The 20 contributors credited on the most AOPs, by distinct-AOP count. Highlights who authors the bulk of the AOP-Wiki and the long tail of one-off contributors.",
+        "data_source": "SPARQL query counts distinct AOPs per dc:creator value. Creator values are free text in the AOP-Wiki (individual names, workgroups, sometimes with affiliations), cleaned in Python by stripping HTML and collapsing whitespace, then truncated for display.",
+        "limitations": "dc:creator is unstructured free text, so a single logical author may appear under several spellings (or bundled with co-authors/affiliations in one string), and workgroups count as one contributor. Counts are therefore indicative of contribution volume, not a normalised author roster. Limited to the top 20.",
+        "queries": [
+            {
+                "caption": "Identify latest graph (AOP anchor)",
+                "query": "SELECT ?graph\nWHERE {\n  GRAPH ?graph { ?s a aopo:AdverseOutcomePathway . }\n  FILTER(STRSTARTS(STR(?graph), \"http://aopwiki.org/graph/\"))\n}\nGROUP BY ?graph\nORDER BY DESC(?graph)\nLIMIT 1"
+            },
+            {
+                "caption": "Top 20 contributors by distinct-AOP count",
+                "query": "SELECT ?creator (COUNT(DISTINCT ?aop) AS ?aop_count)\nWHERE {\n  GRAPH __GRAPH_URI__ {\n    ?aop a aopo:AdverseOutcomePathway ;\n         dc:creator ?creator .\n  }\n}\nGROUP BY ?creator\nORDER BY DESC(?aop_count)\nLIMIT 20"
+            }
+        ]
+    },
     "ontology_term_growth": {
         "title": "Ontology Term Growth Over Time",
         "description": "Tracks the number of unique ontology terms used in biological process and object annotations across database versions. Growth indicates expanding annotation vocabulary and richer biological characterization.",

--- a/static/js/version-selector.js
+++ b/static/js/version-selector.js
@@ -30,6 +30,7 @@
         'latest_ke_reuse',
         'latest_ke_reuse_distribution',
         'latest_top_ontology_terms',
+        'latest_author_contributions',
         'latest_ontology_diversity',
         'latest_organ_coverage_unified',
         'latest_organ_coverage_pie',

--- a/templates/latest.html
+++ b/templates/latest.html
@@ -93,6 +93,28 @@
             </div>
             {{ data_table_toggle('latest_entity_counts') }}
         </div>
+        <div class="plot-box">
+            <div class="plot-header">
+                <h3>Top AOP Contributors</h3>
+                <div class="download-dropdown">
+                    <button class="download-button dropdown-toggle">Download &#x25BC;</button>
+                    <div class="dropdown-menu">
+                        <a href="/download/latest/author_contributions?format=csv" class="dropdown-item">CSV</a>
+                        <a href="/download/latest/author_contributions?format=png" class="dropdown-item">PNG</a>
+                        <a href="/download/latest/author_contributions?format=svg" class="dropdown-item">SVG</a>
+                    </div>
+                </div>
+            </div>
+            <p class="plot-description">
+                The 20 contributors credited on the most AOPs (by distinct-AOP count). Creator values are
+                free text, so counts are indicative of contribution volume rather than a normalised roster.
+            </p>
+            {{ methodology_note(methodology_notes, 'latest_author_contributions') }}
+            <div class="lazy-plot" data-plot-name="latest_author_contributions">
+                <!-- Plot will be loaded here via JavaScript -->
+            </div>
+            {{ data_table_toggle('latest_author_contributions') }}
+        </div>
     </div>
 </section>
 

--- a/tests/test_all_downloads.py
+++ b/tests/test_all_downloads.py
@@ -71,6 +71,7 @@ LATEST_PLOTS = [
     "latest_ke_reuse",
     "latest_ke_reuse_distribution",
     "latest_top_ontology_terms",
+    "latest_author_contributions",
     "latest_ontology_diversity",
     "latest_aop_completeness_unique",
     "latest_organ_coverage",
@@ -271,7 +272,8 @@ def run_audit(client, *, latest: str, historical: str,
     #    route the template actually uses for them.
     for plot in ("latest_ke_by_bio_level", "latest_taxonomic_groups",
                  "latest_entity_by_oecd_status", "latest_ke_reuse",
-                 "latest_ke_reuse_distribution", "latest_top_ontology_terms"):
+                 "latest_ke_reuse_distribution", "latest_top_ontology_terms",
+                 "latest_author_contributions"):
         suffix = plot[len("latest_"):]
         client.get(f"/api/plot/{plot}?version={latest}")
         report.add(_check(client,


### PR DESCRIPTION
Adds the author-contribution view #29 asked for: a top-20 horizontal bar of contributors by distinct-AOP count (`dc:creator`), complementing the existing distinct-authors-over-time trend.

- **Data reality**: `dc:creator` is unstructured free text (names, workgroups, sometimes affiliations/HTML). Labels are cleaned (HTML stripped via `html.unescape` + tag strip, whitespace collapsed) and truncated; the methodology note is explicit that counts are indicative of volume, not a normalised roster. Verified live: top contributors are Cancer AOP Workgroup (17), Kellie Fay (13), etc.
- **Reuses** the `plot_latest_ke_reuse` horizontal-bar pattern (version-suffixed caches, generic `/download/latest/<suffix>` route).
- **Wiring**: `__init__`, `app.py` dispatch + bulk category, `templates/latest.html` (Database State section), `version-selector.js`, `methodology_notes.json` entry, `test_all_downloads.py`.
- **Verified**: renders valid Plotly HTML with correct cached data; `methodology-lint` passes (0 findings).

Closes #29.