### PR TITLE
feat(latest): MIE Stressor Coverage plot (#26)

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,6 +114,7 @@ from plots import (
     plot_latest_entity_by_oecd_status,
     plot_latest_ke_reuse,
     plot_latest_ke_reuse_distribution,
+    plot_latest_stressor_mie_coverage,
     plot_latest_top_ontology_terms,
     plot_latest_ontology_diversity,
     plot_latest_aop_completeness_unique_colors,
@@ -1538,7 +1539,8 @@ def download_bulk():
                 'latest_aop_completeness', 'latest_ke_annotation_depth',
                 'latest_ke_by_bio_level', 'latest_taxonomic_groups',
                 'latest_entity_by_oecd_status', 'latest_ke_reuse',
-                'latest_ke_reuse_distribution', 'latest_top_ontology_terms'
+                'latest_ke_reuse_distribution', 'latest_stressor_mie_coverage',
+                'latest_top_ontology_terms'
             ],
             'database-state': ['latest_entity_counts'],
             'network-analysis': ['latest_aop_connectivity', 'latest_avg_per_aop'],
@@ -1877,6 +1879,7 @@ def get_plot(plot_name):
         'latest_entity_by_oecd_status': plot_latest_entity_by_oecd_status,
         'latest_ke_reuse': plot_latest_ke_reuse,
         'latest_ke_reuse_distribution': plot_latest_ke_reuse_distribution,
+        'latest_stressor_mie_coverage': plot_latest_stressor_mie_coverage,
         'latest_top_ontology_terms': plot_latest_top_ontology_terms,
         'latest_ontology_diversity': plot_latest_ontology_diversity,
         'latest_aop_completeness_unique': plot_latest_aop_completeness_unique_colors,

--- a/plots/__init__.py
+++ b/plots/__init__.py
@@ -218,6 +218,7 @@ from .latest_plots import (
     plot_latest_taxonomic_groups,
     plot_latest_entity_by_oecd_status,
     plot_latest_ke_reuse,
+    plot_latest_stressor_mie_coverage,
     plot_latest_top_ontology_terms,
     plot_latest_ke_reuse_distribution,
 
@@ -314,6 +315,7 @@ __all__ = [
     'plot_latest_taxonomic_groups',
     'plot_latest_entity_by_oecd_status',
     'plot_latest_ke_reuse',
+    'plot_latest_stressor_mie_coverage',
     'plot_latest_top_ontology_terms',
     'plot_latest_ke_reuse_distribution',
     'plot_latest_ontology_diversity',
@@ -389,6 +391,7 @@ def get_available_functions():
             'plot_latest_taxonomic_groups',
             'plot_latest_entity_by_oecd_status',
             'plot_latest_ke_reuse',
+            'plot_latest_stressor_mie_coverage',
             'plot_latest_top_ontology_terms',
             'plot_latest_ke_reuse_distribution',
             'plot_latest_ontology_diversity',

--- a/plots/latest_plots.py
+++ b/plots/latest_plots.py
@@ -2110,6 +2110,117 @@ def plot_latest_ke_reuse_distribution(version: str = None) -> str:
     return render_plot_html(fig)
 
 
+def plot_latest_stressor_mie_coverage(version: str = None) -> str:
+    """Show stressor coverage of Molecular Initiating Events (the MIE gap).
+
+    For each MIE, counts the distinct stressors annotated on the AOPs that
+    contain it (stressors are AOP-level, nci:C54571), then bins MIEs by that
+    count. The "0 (no stressor)" bar is the curation gap — MIEs with no known
+    chemical/biological trigger.
+
+    Args:
+        version: Optional version string. If None, uses latest.
+
+    Returns:
+        str: Plotly HTML string for embedding.
+    """
+    global _plot_data_cache
+
+    # Determine target graph
+    if version:
+        target_graph = f"http://aopwiki.org/graph/{version}"
+        latest_version = version
+    else:
+        version_query = """
+        SELECT ?graph
+        WHERE {
+            GRAPH ?graph { ?s a aopo:AdverseOutcomePathway . }
+            FILTER(STRSTARTS(STR(?graph), "http://aopwiki.org/graph/"))
+        }
+        GROUP BY ?graph
+        ORDER BY DESC(?graph)
+        LIMIT 1
+        """
+        version_results = run_sparql_query(version_query)
+        if not version_results:
+            return create_fallback_plot("MIE Stressor Coverage", "No graphs available")
+        target_graph = version_results[0]["graph"]["value"]
+        latest_version = target_graph.split("/")[-1]
+
+    query = f"""
+    SELECT ?mie (COUNT(DISTINCT ?stressor) AS ?stressor_count)
+    WHERE {{
+      GRAPH <{target_graph}> {{
+        ?aop a aopo:AdverseOutcomePathway ;
+             <http://aopkb.org/aop_ontology#has_molecular_initiating_event> ?mie .
+        OPTIONAL {{ ?aop <http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C54571> ?stressor . }}
+      }}
+    }}
+    GROUP BY ?mie
+    ORDER BY DESC(?stressor_count)
+    """
+
+    results = run_sparql_query(query)
+    if not results:
+        return create_fallback_plot("MIE Stressor Coverage", "No MIE data found")
+
+    bins = ["0 (no stressor)", "1", "2", "3–5", "6–10", "11+"]
+    counts = {b: 0 for b in bins}
+    total = 0
+    covered = 0
+    for r in results:
+        n = int(r["stressor_count"]["value"])
+        total += 1
+        if n > 0:
+            covered += 1
+        if n == 0:
+            b = "0 (no stressor)"
+        elif n == 1:
+            b = "1"
+        elif n == 2:
+            b = "2"
+        elif n <= 5:
+            b = "3–5"
+        elif n <= 10:
+            b = "6–10"
+        else:
+            b = "11+"
+        counts[b] += 1
+
+    if total == 0:
+        return create_fallback_plot("MIE Stressor Coverage", "No MIE data found")
+
+    df = pd.DataFrame([{"Stressors per MIE": b, "MIE Count": counts[b]} for b in bins])
+    version_key = version or "latest"
+    df["Version"] = latest_version
+    _plot_data_cache[f'latest_stressor_mie_coverage_{version_key}'] = df
+
+    pct = round(100 * covered / total)
+    bar_colors = [BRAND_COLORS['magenta'] if b == "0 (no stressor)" else BRAND_COLORS['blue']
+                  for b in bins]
+
+    fig = px.bar(
+        df,
+        x="Stressors per MIE",
+        y="MIE Count",
+        text="MIE Count",
+        category_orders={"Stressors per MIE": bins},
+    )
+    fig.update_traces(marker_color=bar_colors, textposition='outside')
+    fig.update_layout(
+        showlegend=False,
+        height=460,
+        margin=dict(l=60, r=30, t=70, b=60),
+        xaxis=dict(title="Distinct stressors linked (via shared AOPs)"),
+        yaxis=dict(title="Number of MIEs"),
+        title=dict(text=f"{covered} of {total} MIEs ({pct}%) have ≥1 associated stressor",
+                   x=0.5, xanchor='center', font=dict(size=13)),
+    )
+
+    _plot_figure_cache[f'latest_stressor_mie_coverage_{version_key}'] = fig
+    return render_plot_html(fig)
+
+
 def plot_latest_ke_completeness_by_status(version: str = None) -> str:
     """Create a grouped bar chart showing KE completeness scores grouped by OECD status.
 

--- a/static/data/methodology_notes.json
+++ b/static/data/methodology_notes.json
@@ -565,6 +565,22 @@
             }
         ]
     },
+    "latest_stressor_mie_coverage": {
+        "title": "MIE Stressor Coverage",
+        "description": "Bins Molecular Initiating Events by how many distinct stressors are annotated on the AOPs that contain them. The '0 (no stressor)' bar (highlighted) is the curation gap — MIEs with no known chemical/biological trigger. The subtitle reports the overall share of MIEs with at least one associated stressor.",
+        "data_source": "SPARQL query, per MIE, counts distinct stressors (nci:C54571) on the AOPs referencing that MIE via aopo:has_molecular_initiating_event. MIEs are then binned in Python (0, 1, 2, 3-5, 6-10, 11+).",
+        "limitations": "Stressors are annotated at the AOP level, not directly on the MIE, so coverage is inferred through shared AOPs — an AOP's stressors are attributed to its MIE. An MIE shared by several AOPs aggregates all their stressors. Reflects annotation presence, not stressor-MIE causal specificity.",
+        "queries": [
+            {
+                "caption": "Identify latest graph (AOP anchor)",
+                "query": "SELECT ?graph\nWHERE {\n  GRAPH ?graph { ?s a aopo:AdverseOutcomePathway . }\n  FILTER(STRSTARTS(STR(?graph), \"http://aopwiki.org/graph/\"))\n}\nGROUP BY ?graph\nORDER BY DESC(?graph)\nLIMIT 1"
+            },
+            {
+                "caption": "Distinct stressors per MIE (via shared AOPs)",
+                "query": "SELECT ?mie (COUNT(DISTINCT ?stressor) AS ?stressor_count)\nWHERE {\n  GRAPH __GRAPH_URI__ {\n    ?aop a aopo:AdverseOutcomePathway ;\n         <http://aopkb.org/aop_ontology#has_molecular_initiating_event> ?mie .\n    OPTIONAL { ?aop <http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C54571> ?stressor . }\n  }\n}\nGROUP BY ?mie\nORDER BY DESC(?stressor_count)"
+            }
+        ]
+    },
     "latest_ontology_diversity": {
         "title": "Ontology Term Diversity",
         "description": "Counts the number of unique ontology terms used per source ontology (GO, CHEBI, UBERON, NCBITAXON, etc.) in KE annotations. Shows the breadth of ontology vocabulary in use.",

--- a/static/js/version-selector.js
+++ b/static/js/version-selector.js
@@ -29,6 +29,7 @@
         'latest_entity_by_oecd_status',
         'latest_ke_reuse',
         'latest_ke_reuse_distribution',
+        'latest_stressor_mie_coverage',
         'latest_top_ontology_terms',
         'latest_ontology_diversity',
         'latest_organ_coverage_unified',

--- a/templates/latest.html
+++ b/templates/latest.html
@@ -416,6 +416,29 @@
             </div>
             {{ data_table_toggle('latest_life_stage') }}
         </div>
+        <div class="plot-box">
+            <div class="plot-header">
+                <h3>MIE Stressor Coverage</h3>
+                <div class="download-dropdown">
+                    <button class="download-button dropdown-toggle">Download &#x25BC;</button>
+                    <div class="dropdown-menu">
+                        <a href="/download/latest/stressor_mie_coverage?format=csv" class="dropdown-item">CSV</a>
+                        <a href="/download/latest/stressor_mie_coverage?format=png" class="dropdown-item">PNG</a>
+                        <a href="/download/latest/stressor_mie_coverage?format=svg" class="dropdown-item">SVG</a>
+                    </div>
+                </div>
+            </div>
+            <p class="plot-description">
+                Molecular Initiating Events binned by how many distinct stressors are annotated on the AOPs
+                that contain them. The highlighted "0 (no stressor)" bar is the curation gap. Stressors are
+                AOP-level annotations attributed to the MIE via shared AOPs.
+            </p>
+            {{ methodology_note(methodology_notes, 'latest_stressor_mie_coverage') }}
+            <div class="lazy-plot" data-plot-name="latest_stressor_mie_coverage">
+                <!-- Plot will be loaded here via JavaScript -->
+            </div>
+            {{ data_table_toggle('latest_stressor_mie_coverage') }}
+        </div>
 
     </div>
 </section>

--- a/tests/test_all_downloads.py
+++ b/tests/test_all_downloads.py
@@ -70,6 +70,7 @@ LATEST_PLOTS = [
     "latest_entity_by_oecd_status",
     "latest_ke_reuse",
     "latest_ke_reuse_distribution",
+    "latest_stressor_mie_coverage",
     "latest_top_ontology_terms",
     "latest_ontology_diversity",
     "latest_aop_completeness_unique",
@@ -271,7 +272,8 @@ def run_audit(client, *, latest: str, historical: str,
     #    route the template actually uses for them.
     for plot in ("latest_ke_by_bio_level", "latest_taxonomic_groups",
                  "latest_entity_by_oecd_status", "latest_ke_reuse",
-                 "latest_ke_reuse_distribution", "latest_top_ontology_terms"):
+                 "latest_ke_reuse_distribution", "latest_top_ontology_terms",
+                 "latest_stressor_mie_coverage"):
         suffix = plot[len("latest_"):]
         client.get(f"/api/plot/{plot}?version={latest}")
         report.add(_check(client,


### PR DESCRIPTION
Adds the stressor→MIE coverage/gap view #26 asked for. For each Molecular Initiating Event it counts the distinct stressors annotated on the AOPs that contain it, then bins MIEs (0 / 1 / 2 / 3–5 / 6–10 / 11+).

- **Coverage story (verified live)**: 281 MIEs; **129 (46%) have no associated stressor** (the highlighted gap bar), 152 (54%) have ≥1, long tail to 23. The subtitle reports the coverage %.
- **Honest semantics**: stressors are AOP-level annotations (`nci:C54571`), so coverage is inferred through shared AOPs and attributed to the MIE via `aopo:has_molecular_initiating_event` — spelled out in the methodology limitations (not a direct stressor→MIE causal link).
- **Reuses** the binned-distribution + version-suffixed-cache recipe; placed in the Coverage Analysis section.
- **Verified**: renders valid Plotly HTML with correct binned data; `methodology-lint` passes (0 findings; needed an `ORDER BY DESC(?stressor_count)` so the lint's LIMIT-1 sample isn't a legitimately-zero MIE).

Closes #26.