### PR TITLE
ci(methodology-lint): comment on PR only when the lint fails

### DIFF
--- a/.github/workflows/methodology-lint.yml
+++ b/.github/workflows/methodology-lint.yml
@@ -79,8 +79,10 @@ jobs:
             lint-report.md
             lint-report.json
 
-      - name: Comment on PR with lint report
-        if: always() && github.event_name == 'pull_request'
+      - name: Comment on PR only when the lint fails
+        # Only comment on failures — a passing lint already shows as a green
+        # check, so commenting on every run just generates notification noise.
+        if: steps.lint.outcome == 'failure' && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Stops the 'Methodology lint: … All checks passed' PR comment (and its notification email) that fired on every run. A passing lint already surfaces as a green check; the detailed report comment is only useful on a **failure**, so the comment step is now gated on `steps.lint.outcome == 'failure'`. `download-audit.yml` already behaves this way (failure-only). Fully removing the comment would also work, but failure-only keeps the useful signal.