### PR TITLE
fix: top five frontend review findings (#123-#127)

### DIFF
--- a/plots/__init__.py
+++ b/plots/__init__.py
@@ -114,6 +114,7 @@ from .shared import (
     get_all_versions,
 
     # Utility functions
+    apply_snapshot_xaxis,
     safe_read_csv,
     get_properties_for_entity,
     safe_plot_execution,
@@ -258,6 +259,7 @@ __all__ = [
     'check_sparql_endpoint_health',
     'get_latest_version',
     'get_all_versions',
+    'apply_snapshot_xaxis',
     'safe_read_csv',
     'get_properties_for_entity',
     'safe_plot_execution',

--- a/plots/shared.py
+++ b/plots/shared.py
@@ -1303,6 +1303,31 @@ def export_figure_as_image(
         return None
 
 
+def apply_snapshot_xaxis(fig, title: str = "Snapshot date"):
+    """Format the quarterly-snapshot x-axis of a trend figure.
+
+    Trend plots feed YYYY-MM-DD **strings** to Plotly, which auto-detects a
+    date axis and thins the tick labels to fit — one per year or two at the
+    ~500px card widths used on /trends.
+
+    Two things break that and should not be reintroduced:
+
+    * ``tickmode='array'`` with every snapshot as an explicit tickval. All 33
+      dates then render at -45° inside the card and collapse into an illegible
+      smear (#127). Let Plotly choose the ticks instead.
+    * Converting the x values to datetimes. ``_figure_x_categories`` only
+      collects ``str`` x-values, so the /trends date-range selector would
+      silently stop clamping the figure (see ``_clamp_figure_to_range``).
+
+    Args:
+        fig: Plotly figure whose x-axis carries YYYY-MM-DD strings.
+        title: Axis title. Defaults to the reader-facing "Snapshot date"
+            rather than the raw ``version`` column name.
+    """
+    fig.update_xaxes(title_text=title, tickangle=0)
+    return fig
+
+
 def _clamp_figure_to_range(fig, start: Optional[str], end: Optional[str]):
     """Return a deep-copied figure with its x-axis clamped to [start, end].
 

--- a/plots/trends_plots.py
+++ b/plots/trends_plots.py
@@ -61,7 +61,7 @@ from .shared import (
     BRAND_COLORS, config, _plot_data_cache, _plot_figure_cache,
     run_sparql_query, run_sparql_query_with_retry, extract_counts,
     safe_read_csv, create_fallback_plot, get_properties_for_entity,
-    get_all_versions, render_plot_html,
+    get_all_versions, render_plot_html, apply_snapshot_xaxis,
     ENTITY_TYPE_CLASSES, diff_entities_between_versions,
     fetch_entity_uris_by_version,
 )
@@ -236,12 +236,7 @@ def plot_main_graph() -> tuple[str, str, pd.DataFrame]:
         fig_abs.update_layout(
             margin=dict(l=50, r=20, t=50, b=50)
         )
-        fig_abs.update_xaxes(
-            tickmode='array',
-            tickvals=df_all["version"],
-            ticktext=df_all["version"],
-            tickangle=-45
-        )
+        apply_snapshot_xaxis(fig_abs)
 
         # --- Delta plot ---
         df_delta = df_all.copy()
@@ -264,12 +259,7 @@ def plot_main_graph() -> tuple[str, str, pd.DataFrame]:
         fig_delta.update_layout(
             margin=dict(l=50, r=20, t=50, b=50)
         )
-        fig_delta.update_xaxes(
-            tickmode='array',
-            tickvals=df_all["version"],
-            ticktext=df_all["version"],
-            tickangle=-45
-        )
+        apply_snapshot_xaxis(fig_delta)
 
         # Store absolute and delta data in cache for CSV download.
         # Legacy `main_graph_*` keys kept for backwards-compat with old

--- a/static/css/lazy-loading.css
+++ b/static/css/lazy-loading.css
@@ -100,7 +100,7 @@
 }
 
 .plot-error .error-retry-btn {
-    background-color: #307BBF;
+    background-color: var(--color-blue-ui);
     color: white;
     border: none;
     padding: 8px 24px;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -9,6 +9,11 @@
     --color-magenta: #E6007E;
     --color-blue: #307BBF;
     --color-light-blue: #009FE3;
+    /* Interface blue. #307BBF is 4.46:1 on white and 4.09:1 on #f5f5f5, both
+       under the 4.5:1 WCAG AA floor, so chrome (links, labels, button fills)
+       uses this darker variant: 5.45:1 on white, 5.00:1 on #f5f5f5. Charts keep
+       --color-blue so plots stay in sync with plots/shared.py BRAND_COLORS. */
+    --color-blue-ui: #2A6DA8;
     --color-orange: #EB5B25;
     --color-sky-blue: #93D5F6;
     --color-deep-magenta: #9A1C57;
@@ -256,7 +261,7 @@ footer img {
 }
 
 #dropdown-table th {
-    background-color: var(--color-blue);
+    background-color: var(--color-blue-ui);
     color: white;
     font-weight: bold;
 }
@@ -299,7 +304,7 @@ footer img {
 }
 
 .download-button {
-    background-color: var(--color-blue);
+    background-color: var(--color-blue-ui);
     color: white;
     padding: 6px 12px;
     border: none;
@@ -331,14 +336,14 @@ footer img {
 }
 
 .aop-aop-threshold-control input[type="range"] {
-    accent-color: var(--color-blue);
+    accent-color: var(--color-blue-ui);
     width: 140px;
     cursor: pointer;
 }
 
 .aop-aop-threshold-control #aop-aop-threshold-value {
     font-weight: 600;
-    color: var(--color-blue);
+    color: var(--color-blue-ui);
     min-width: 1.4em;
     display: inline-block;
     text-align: right;
@@ -432,7 +437,7 @@ footer img {
     color: var(--color-primary);
     text-align: center;
     margin: 20px 0;
-    border-bottom: 2px solid var(--color-blue);
+    border-bottom: 2px solid var(--color-blue-ui);
     padding-bottom: 10px;
 }
 
@@ -476,7 +481,7 @@ footer img {
 
 .tab-button:hover {
     background-color: rgba(48, 123, 191, 0.1);
-    color: var(--color-blue);
+    color: var(--color-blue-ui);
 }
 
 .tab-button.active {
@@ -633,7 +638,7 @@ footer img {
 }
 
 .card-icon {
-    color: var(--color-blue);
+    color: var(--color-blue-ui);
     margin-bottom: 16px;
 }
 
@@ -673,7 +678,7 @@ footer img {
 .aopwiki-intro > summary {
     cursor: pointer;
     padding: 10px 14px;
-    color: var(--color-blue);
+    color: var(--color-blue-ui);
     font-weight: 500;
     user-select: none;
 }
@@ -694,7 +699,7 @@ footer img {
 }
 
 .intro-content a {
-    color: var(--color-blue);
+    color: var(--color-blue-ui);
     text-decoration: none;
 }
 
@@ -771,7 +776,7 @@ footer img {
 }
 
 .about-link {
-    color: var(--color-blue);
+    color: var(--color-blue-ui);
     text-decoration: none;
 }
 
@@ -780,7 +785,7 @@ footer img {
 }
 
 .about-section a:not(.about-link) {
-    color: var(--color-blue);
+    color: var(--color-blue-ui);
     text-decoration: none;
 }
 
@@ -855,7 +860,7 @@ footer img {
 
 /* Version Banner (Historical Version Indicator) */
 .version-banner {
-    background: linear-gradient(135deg, var(--color-blue) 0%, #4a94d4 100%);
+    background: linear-gradient(135deg, var(--color-blue-ui) 0%, #4a94d4 100%);
     color: white;
     padding: 15px 30px;
     margin: 0 auto 20px;
@@ -898,7 +903,7 @@ footer img {
 
 .version-banner-reset {
     background: white;
-    color: var(--color-blue);
+    color: var(--color-blue-ui);
     border: none;
     padding: 8px 16px;
     border-radius: 6px;
@@ -960,7 +965,7 @@ footer img {
 .methodology-note > summary {
     cursor: pointer;
     padding: 10px 14px;
-    color: var(--color-blue);
+    color: var(--color-blue-ui);
     font-weight: 600;
     font-size: 15px;
     user-select: none;
@@ -988,7 +993,7 @@ footer img {
 
 .sparql-query > summary {
     cursor: pointer;
-    color: var(--color-blue);
+    color: var(--color-blue-ui);
     font-size: 14px;
     font-weight: 500;
     margin-top: 8px;
@@ -1022,7 +1027,7 @@ footer img {
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    background-color: var(--color-blue);
+    background-color: var(--color-blue-ui);
     color: #fff;
     padding: 8px 16px;
     border-radius: 4px;
@@ -1043,19 +1048,19 @@ footer img {
     align-items: center;
     gap: 4px;
     background-color: transparent;
-    color: var(--color-blue);
+    color: var(--color-blue-ui);
     padding: 8px 16px;
     border-radius: 4px;
     font-size: 12px;
     font-weight: 400;
-    border: 1px solid var(--color-blue);
+    border: 1px solid var(--color-blue-ui);
     cursor: pointer;
     transition: all 0.3s ease;
 }
 
 .sparql-copy-btn:hover {
     background-color: rgba(48, 123, 191, 0.1);
-    color: var(--color-blue);
+    color: var(--color-blue-ui);
 }
 
 /* ============================================
@@ -1068,8 +1073,8 @@ footer img {
 
 .data-table-toggle {
     background-color: transparent;
-    color: var(--color-blue);
-    border: 1px solid var(--color-blue);
+    color: var(--color-blue-ui);
+    border: 1px solid var(--color-blue-ui);
     padding: 6px 14px;
     border-radius: 4px;
     cursor: pointer;
@@ -1079,7 +1084,7 @@ footer img {
 }
 
 .data-table-toggle:hover {
-    background-color: var(--color-blue);
+    background-color: var(--color-blue-ui);
     color: white;
 }
 
@@ -1605,7 +1610,7 @@ footer img {
     margin: 0;
     font-size: 13px;
     border-radius: 4px;
-    background-color: var(--color-blue);
+    background-color: var(--color-blue-ui);
 }
 
 .nav-button--compact:hover {
@@ -1672,19 +1677,19 @@ footer img {
 
 .segmented-control {
     display: inline-flex;
-    border: 1px solid var(--color-blue);
+    border: 1px solid var(--color-blue-ui);
     border-radius: 6px;
     overflow: hidden;
 }
 
 .segmented-button {
     background-color: white;
-    color: var(--color-blue);
+    color: var(--color-blue-ui);
     border: none;
     padding: 6px 14px;
     font-size: 13px;
     cursor: pointer;
-    border-right: 1px solid var(--color-blue);
+    border-right: 1px solid var(--color-blue-ui);
     transition: background-color 0.15s ease, color 0.15s ease;
 }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -368,7 +368,11 @@ footer img {
     border: 1px solid #ddd;
 }
 
-.download-dropdown:hover .dropdown-menu {
+/* Click-toggled, not hover-opened: a :hover-only menu keeps its links inside a
+   display:none container, so they never enter the tab order and the whole
+   download path is unreachable by keyboard. download-dropdown.js owns .is-open
+   and the matching aria-expanded. */
+.download-dropdown .dropdown-menu.is-open {
     display: block;
 }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1359,8 +1359,16 @@ footer img {
    Page Content (base.html)
    ========================================================================== */
 
+/* body.site-body is a column flex container, so the auto inline margins here
+   suppress the default cross-axis stretch and the element would otherwise
+   shrink to fit its content — leaving /network, /about and / narrower than the
+   nav and footer. width + border-box restores the fill; the max-width includes
+   the 20px gutters so the content edge lands on the same x as .nav-container
+   and .footer-container. */
 .page-content {
-    max-width: var(--content-max-width);
+    width: 100%;
+    box-sizing: border-box;
+    max-width: calc(var(--content-max-width) + 40px);
     margin: 0 auto;
     padding: 0 20px;
     flex: 1;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -421,6 +421,9 @@ footer img {
 .section-block {
     width: 100%;
     margin: 40px auto;
+    /* Clears the sticky .snapshot-section-nav so a jumped-to heading isn't
+       hidden behind it. */
+    scroll-margin-top: 60px;
 }
 
 .section-header {
@@ -1580,12 +1583,21 @@ footer img {
     margin: -10px auto 14px;
 }
 
+/* Sticky on /snapshot and /trends: both pages run past 14,000px, so section
+   jumps have to stay reachable while scrolling. Negative inline margins let the
+   bar's background span the full content width behind the page gutters. */
 .snapshot-section-nav {
     display: flex;
     flex-wrap: wrap;
     gap: 6px;
     justify-content: center;
-    margin: 0 auto 14px;
+    position: sticky;
+    top: 0;
+    z-index: 90;
+    background-color: var(--color-bg);
+    margin: 0 -20px 14px;
+    padding: 8px 20px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
 }
 
 .nav-button--compact {

--- a/static/css/network.css
+++ b/static/css/network.css
@@ -37,7 +37,7 @@
 
 .tab-btn:hover {
     background-color: rgba(48, 123, 191, 0.08);
-    color: #307BBF;
+    color: var(--color-blue-ui);
 }
 
 .tab-btn.active {
@@ -106,7 +106,7 @@
 
 .filter-select:focus {
     outline: none;
-    border-color: #307BBF;
+    border-color: var(--color-blue-ui);
 }
 
 .reset-btn {
@@ -144,7 +144,7 @@
 
 .search-input:focus {
     outline: none;
-    border-color: #307BBF;
+    border-color: var(--color-blue-ui);
     box-shadow: 0 0 0 2px rgba(48, 123, 191, 0.2);
 }
 
@@ -422,7 +422,7 @@
 .wiki-link {
     display: inline-block;
     padding: 8px 16px;
-    background: #307BBF;
+    background: var(--color-blue-ui);
     color: white;
     text-decoration: none;
     border-radius: 4px;

--- a/static/js/download-dropdown.js
+++ b/static/js/download-dropdown.js
@@ -1,0 +1,92 @@
+/**
+ * Download Dropdowns for AOP-Wiki RDF Dashboard
+ *
+ * Opens the per-plot and page-level download menus on click rather than hover.
+ * Hover-only menus leave their links inside a display:none container, so they
+ * never enter the tab order and cannot be reached by keyboard; they are also
+ * unreliable on touch, where :hover latching varies by browser.
+ *
+ * Click delegation is used so menus rendered after page load still work.
+ */
+
+(function () {
+    'use strict';
+
+    var OPEN_CLASS = 'is-open';
+
+    function menuFor(toggle) {
+        var wrapper = toggle.closest('.download-dropdown');
+        return wrapper ? wrapper.querySelector('.dropdown-menu') : null;
+    }
+
+    function setState(toggle, open) {
+        var menu = menuFor(toggle);
+        if (!menu) return;
+        menu.classList.toggle(OPEN_CLASS, open);
+        toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    }
+
+    function closeAll(except) {
+        document.querySelectorAll('.download-dropdown .dropdown-menu.' + OPEN_CLASS)
+            .forEach(function (menu) {
+                var toggle = menu.parentElement.querySelector('.dropdown-toggle');
+                if (toggle && toggle !== except) setState(toggle, false);
+            });
+    }
+
+    /** Describe each toggle to assistive tech. Safe to call repeatedly. */
+    function annotate(root) {
+        (root || document).querySelectorAll('.download-dropdown .dropdown-toggle')
+            .forEach(function (toggle) {
+                if (!toggle.hasAttribute('type')) toggle.setAttribute('type', 'button');
+                toggle.setAttribute('aria-haspopup', 'true');
+                if (!toggle.hasAttribute('aria-expanded')) {
+                    toggle.setAttribute('aria-expanded', 'false');
+                }
+            });
+    }
+
+    document.addEventListener('click', function (event) {
+        var toggle = event.target.closest('.download-dropdown .dropdown-toggle');
+
+        if (toggle) {
+            event.preventDefault();
+            var menu = menuFor(toggle);
+            var willOpen = !!menu && !menu.classList.contains(OPEN_CLASS);
+            closeAll(toggle);
+            setState(toggle, willOpen);
+            return;
+        }
+
+        // A click on a menu item starts a download; close the menu behind it.
+        // Any other click outside dismisses whatever is open.
+        closeAll(null);
+    });
+
+    document.addEventListener('keydown', function (event) {
+        if (event.key !== 'Escape') return;
+        var wrapper = event.target.closest('.download-dropdown');
+        closeAll(null);
+        if (wrapper) {
+            var toggle = wrapper.querySelector('.dropdown-toggle');
+            if (toggle) toggle.focus();
+        }
+    });
+
+    // Tabbing out of an open dropdown dismisses it.
+    document.addEventListener('focusin', function (event) {
+        document.querySelectorAll('.download-dropdown').forEach(function (wrapper) {
+            if (wrapper.contains(event.target)) return;
+            var toggle = wrapper.querySelector('.dropdown-toggle');
+            if (toggle) setState(toggle, false);
+        });
+    });
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () { annotate(); });
+    } else {
+        annotate();
+    }
+
+    window.annotateDownloadDropdowns = annotate;
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -60,6 +60,7 @@
     </footer>
 
     <script src="{{ url_for('static', filename='js/lazy-loading.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/download-dropdown.js') }}"></script>
     {% block scripts_extra %}{% endblock %}
 </body>
 </html>

--- a/templates/latest.html
+++ b/templates/latest.html
@@ -693,7 +693,7 @@
             </p>
             {{ methodology_note(methodology_notes, 'latest_aop_completeness_by_status') }}
             <details style="margin-top: 10px;">
-                <summary style="cursor: pointer; color: #307BBF; font-weight: 500;">Show property details</summary>
+                <summary style="cursor: pointer; color: var(--color-blue-ui); font-weight: 500;">Show property details</summary>
                 <div id="aop-properties-details" class="property-details" data-entity-type="AOP" style="margin-top: 10px; padding: 10px; background-color: #f9f9f9; border-radius: 4px; font-size: 13px;">
                     Loading properties...
                 </div>
@@ -725,7 +725,7 @@
             </p>
             {{ methodology_note(methodology_notes, 'latest_ke_completeness_by_status') }}
             <details style="margin-top: 10px;">
-                <summary style="cursor: pointer; color: #307BBF; font-weight: 500;">Show property details</summary>
+                <summary style="cursor: pointer; color: var(--color-blue-ui); font-weight: 500;">Show property details</summary>
                 <div id="ke-properties-details" class="property-details" data-entity-type="KE" style="margin-top: 10px; padding: 10px; background-color: #f9f9f9; border-radius: 4px; font-size: 13px;">
                     Loading properties...
                 </div>
@@ -756,7 +756,7 @@
             </p>
             {{ methodology_note(methodology_notes, 'latest_ker_completeness_by_status') }}
             <details style="margin-top: 10px;">
-                <summary style="cursor: pointer; color: #307BBF; font-weight: 500;">Show property details</summary>
+                <summary style="cursor: pointer; color: var(--color-blue-ui); font-weight: 500;">Show property details</summary>
                 <div id="ker-properties-details" class="property-details" data-entity-type="KER" style="margin-top: 10px; padding: 10px; background-color: #f9f9f9; border-radius: 4px; font-size: 13px;">
                     Loading properties...
                 </div>

--- a/templates/usage.html
+++ b/templates/usage.html
@@ -9,7 +9,7 @@
     .usage-card h3 { color: #29235C; margin-top: 0; font-size: 1rem; }
     .usage-card table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
     .usage-card td { padding: 0.2rem 0; border-bottom: 1px solid #f0f0f0; }
-    .usage-card td.count { text-align: right; font-variant-numeric: tabular-nums; color: #307BBF; font-weight: 600; }
+    .usage-card td.count { text-align: right; font-variant-numeric: tabular-nums; color: var(--color-blue-ui); font-weight: 600; }
     .usage-total { font-size: 2rem; color: #E6007E; font-weight: 700; }
     .usage-note { color: #666; font-size: 0.85rem; margin-top: 1.5rem; }
 </style>


### PR DESCRIPTION
Fixes the five highest-severity findings from a frontend/UI review of the deployed dashboard. One commit per issue.

| Commit | Issue | Change |
|---|---|---|
| `b32d53e` | #123 | Download dropdowns open on click, not hover |
| `5cb7944` | #124 | `.page-content` fills the available width |
| `81da1be` | #125 | Section nav is sticky |
| `2eeb3af` | #126 | Interface blue raised to AA contrast |
| `8668370` | #127 | Snapshot x-axis ticks thinned by Plotly |

## Why these five

- **#123** was the only Level-A failure: 31 download menus per page plus "Download all" were unreachable by keyboard, because a `:hover`-only menu keeps its links inside a `display:none` container.
- **#124** was capping `/network` at 840px and the Cytoscape canvas at 800px on any screen size, and putting header, footer and body content on three different grids.
- **#125** left a 14,300px page with no persistent navigation.
- **#126** put the most-used interactive colour under the AA floor on both background colours.
- **#127** made one chart's x-axis unreadable while its neighbour, over the same domain, rendered fine.

## Notes on approach

**#127 — the obvious fix was wrong.** Converting the x-axis to real datetimes would have silently broken the `/trends` date-range selector: `_figure_x_categories` only collects `str` x-values, so the clamp would have degraded to a no-op — the same failure mode as #44/#61. Keeping the strings and just dropping the tick override gives the same result. `apply_snapshot_xaxis()` in `shared.py` documents both traps and is ready for the ~18 other call sites that share the forced-tick pattern; they are deliberately not swept here so this PR stays reviewable.

**#125 needed a companion fix.** Making the nav sticky put every jump target behind the pinned bar, so `.section-block` gains `scroll-margin-top`.

**#126 is deliberately partial.** `.type-badge.ke` and the network legend dot stay on the chart blue: they encode the KE role and must keep matching the Cytoscape node fill. They do carry white text at 4.46:1, so they still need a decision — but one that moves the graph node palette at the same time. Noted on #126.

## Verification

Run against a local instance pointed at the live SPARQL endpoint (41/41 plots loaded):

- **#123** — full keyboard cycle: Enter opens, Tab reaches the CSV link, Escape closes and returns focus to the toggle, `aria-expanded` tracks throughout.
- **#124** — `.page-content` and `.nav-container` both measure 1000–2440; `#cy-container` 800px → 1400px.
- **#125** — pinned at `top: 0` while scrolled; jumping to Coverage Analysis lands the heading at y=110, clear of the bar at y=41.
- **#126** — contrast recomputed at 5.45:1 / 5.00:1; all pages re-rendered.
- **#127** — axis reads `2018 / 2020 / 2022 / 2024 / 2026` horizontally. Range selector re-checked: 2022-01-01 → 2024-01-01 still clamps correctly, and Plotly now re-thins ticks to `Jan 2022 / Jul 2022 / …` within the narrowed range, which the forced-tick version could not do.
- 30 tests pass; methodology-lint clean (55 entries, 0 failures).

## Not covered

Mobile is unverified — window resizing was unavailable in the review environment, so behaviour below 768px is untested for all five. The sticky bar wraps to multiple rows at narrow widths and may want a compacted treatment there.

Remaining findings are tracked in #128–#132.
