### PR TITLE
fix: OECD chart ordering and stuck plot loads (#128, #129)

### DIFF
--- a/plots/latest_plots.py
+++ b/plots/latest_plots.py
@@ -67,7 +67,7 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from .shared import (
     BRAND_COLORS, config, _plot_data_cache, _plot_figure_cache, run_sparql_query, safe_read_csv, create_fallback_plot,
-    render_plot_html
+    render_plot_html, OECD_STATUS_ORDER, PROPERTY_TYPE_ORDER
 )
 from .organ_systems import (
     ORGAN_SYSTEM_BUCKETS,
@@ -1363,7 +1363,13 @@ def plot_latest_aop_completeness_by_status(version: str = None) -> str:
         color="Property Type",
         text="Completeness",
         color_discrete_map=color_map,
-        barmode="group"
+        barmode="group",
+        # Ordinal status order + fixed property order, so this chart and its
+        # siblings can be read against each other (#128).
+        category_orders={
+            "OECD Status": OECD_STATUS_ORDER,
+            "Property Type": PROPERTY_TYPE_ORDER,
+        }
     )
 
     fig.update_traces(texttemplate='%{text:.1f}%', textposition='outside')
@@ -1754,6 +1760,9 @@ def plot_latest_entity_by_oecd_status(version: str = None) -> str:
         barmode="group",
         text="Count",
         color_discrete_map=status_colors,
+        # Same ordinal status order as the completeness charts (#128), so the
+        # legend reads least → most mature everywhere status appears.
+        category_orders={"OECD Status": OECD_STATUS_ORDER},
     )
 
     fig.update_traces(textposition='outside')
@@ -2870,7 +2879,13 @@ def plot_latest_ke_completeness_by_status(version: str = None) -> str:
         color="Property Type",
         text="Completeness",
         color_discrete_map=color_map,
-        barmode="group"
+        barmode="group",
+        # Ordinal status order + fixed property order, so this chart and its
+        # siblings can be read against each other (#128).
+        category_orders={
+            "OECD Status": OECD_STATUS_ORDER,
+            "Property Type": PROPERTY_TYPE_ORDER,
+        }
     )
 
     fig.update_traces(texttemplate='%{text:.1f}%', textposition='outside')
@@ -3056,7 +3071,13 @@ def plot_latest_ker_completeness_by_status(version: str = None) -> str:
         color="Property Type",
         text="Completeness",
         color_discrete_map=color_map,
-        barmode="group"
+        barmode="group",
+        # Ordinal status order + fixed property order, so this chart and its
+        # siblings can be read against each other (#128).
+        category_orders={
+            "OECD Status": OECD_STATUS_ORDER,
+            "Property Type": PROPERTY_TYPE_ORDER,
+        }
     )
 
     fig.update_traces(texttemplate='%{text:.1f}%', textposition='outside')

--- a/plots/shared.py
+++ b/plots/shared.py
@@ -179,6 +179,32 @@ class VersionedPlotCache:
 if not Config.validate_config():
     logger.error("Invalid configuration detected, using defaults")
 
+# OECD status is an *ordinal* scale — curation maturity, not an arbitrary set.
+# Pass this as a Plotly `category_orders` entry wherever status appears on an
+# axis or in a legend, so the axis order carries meaning and sibling charts stay
+# comparable. Without it, order falls out of DataFrame insertion order and two
+# charts of the same shape can disagree (issue #128).
+# Verified against the 2026-07-01 graph: these are the only four values.
+# Statuses absent from this list are appended by Plotly rather than dropped, so
+# a new OECD status will still render — just re-order this list when one appears.
+OECD_STATUS_ORDER = [
+    "No Status",
+    "Under Development",
+    "Under Review",
+    "WPHA/WNT Endorsed",
+]
+
+# Property types ordered core → peripheral, matching how the completeness charts
+# are read: is the entity identified at all, then described, then contextualised,
+# then assessed, then book-kept.
+PROPERTY_TYPE_ORDER = [
+    "Essential",
+    "Content",
+    "Context",
+    "Assessment",
+    "Metadata",
+]
+
 SPARQL_ENDPOINT = Config.SPARQL_ENDPOINT
 MAX_RETRIES = Config.SPARQL_MAX_RETRIES
 RETRY_DELAY = Config.SPARQL_RETRY_DELAY
@@ -218,6 +244,11 @@ BRAND_COLORS = {
     'light': '#93D5F6',
     'content': '#EB5B25',
     # Property type colors using house style palette
+    # NOTE: the 'oecd_status' map above is stale — the live data carries only
+    # 'Under Development', 'Under Review', 'WPHA/WNT Endorsed' and the synthetic
+    # 'No Status' (verified on 2026-07-01). Keys like 'EAGMST Under Review',
+    # 'TFHA/WNT Endorsed', 'Approved' and 'Not OECD' no longer occur, and the two
+    # statuses that do occur are missing. Tracked separately; see OECD_STATUS_ORDER.
     'type_colors': {
         'Essential': '#29235C',    # Primary Dark
         'Metadata': '#E6007E',     # Primary Magenta

--- a/static/js/lazy-loading.js
+++ b/static/js/lazy-loading.js
@@ -9,6 +9,8 @@ class PlotLazyLoader {
     constructor() {
         this.loadedPlots = new Set();
         this.loadingPlots = new Set();
+        this.queue = [];
+        this.activeCount = 0;
         this.observer = null;
         this.init();
     }
@@ -72,7 +74,11 @@ class PlotLazyLoader {
         );
     }
 
-    async loadPlot(element) {
+    /**
+     * Queue a plot for loading. The skeleton appears immediately; the request
+     * itself waits for a free slot.
+     */
+    loadPlot(element) {
         const plotName = element.dataset.plotName;
         console.log(`PlotLazyLoader: Attempting to load plot: ${plotName}`);
 
@@ -82,12 +88,42 @@ class PlotLazyLoader {
         }
 
         this.loadingPlots.add(plotName);
+        this.showLoadingState(element);
+        this.queue.push(element);
+        this.pumpQueue();
+    }
+
+    /**
+     * Start queued fetches up to MAX_CONCURRENT.
+     *
+     * Every /api/plot/<name> call runs a SPARQL query server-side. Scrolling
+     * quickly used to fire all of them at once, so the browser's per-host
+     * connection cap queued them opaquely and the tail requests starved — which
+     * is what produced apparently-stuck plots. Bounding it here keeps the wait
+     * visible to the timeout in fetchPlot() instead.
+     */
+    pumpQueue() {
+        while (this.activeCount < PlotLazyLoader.MAX_CONCURRENT && this.queue.length > 0) {
+            const element = this.queue.shift();
+            this.activeCount++;
+            this.fetchPlot(element).finally(() => {
+                this.activeCount--;
+                this.pumpQueue();
+            });
+        }
+    }
+
+    async fetchPlot(element) {
+        const plotName = element.dataset.plotName;
         console.log(`PlotLazyLoader: Starting load for plot: ${plotName}`);
 
-        try {
-            // Show loading state
-            this.showLoadingState(element);
+        // Without an abort signal a hung backend leaves the promise unsettled
+        // forever: the spinner stays up, the catch below never runs, and the
+        // user gets no error and no Retry (issue #129).
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), PlotLazyLoader.LOAD_TIMEOUT_MS);
 
+        try {
             // Forward any data-* attributes that map to plot kwargs (scope, view).
             // Lets the coverage toggles drive the initial render via markup alone.
             const params = new URLSearchParams();
@@ -98,7 +134,7 @@ class PlotLazyLoader {
 
             // Fetch plot data
             console.log(`PlotLazyLoader: Fetching data for plot: ${plotName} (${url})`);
-            const response = await fetch(url);
+            const response = await fetch(url, { signal: controller.signal });
             console.log(`PlotLazyLoader: Response status for ${plotName}: ${response.status}`);
 
             const data = await response.json();
@@ -151,9 +187,17 @@ class PlotLazyLoader {
                 this.showErrorState(element, data.error);
             }
         } catch (error) {
-            console.error(`PlotLazyLoader: Exception loading plot ${plotName}:`, error);
-            this.showErrorState(element, 'Failed to load plot: ' + error.message);
+            if (error.name === 'AbortError') {
+                const seconds = Math.round(PlotLazyLoader.LOAD_TIMEOUT_MS / 1000);
+                console.error(`PlotLazyLoader: Timeout loading plot ${plotName} after ${seconds}s`);
+                // Phrased so showErrorState() picks its timeout branch.
+                this.showErrorState(element, `Request timeout after ${seconds}s`);
+            } else {
+                console.error(`PlotLazyLoader: Exception loading plot ${plotName}:`, error);
+                this.showErrorState(element, 'Failed to load plot: ' + error.message);
+            }
         } finally {
+            clearTimeout(timeoutId);
             this.loadingPlots.delete(plotName);
         }
     }
@@ -212,6 +256,12 @@ class PlotLazyLoader {
         }
     }
 }
+
+/** Cap on in-flight /api/plot requests; each one runs a SPARQL query. */
+PlotLazyLoader.MAX_CONCURRENT = 4;
+
+/** Give up on a plot request after this long and show the retryable error. */
+PlotLazyLoader.LOAD_TIMEOUT_MS = 45000;
 
 // Initialize lazy loader when DOM is ready
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
Fixes the two remaining high-severity findings from the frontend review. One commit each.

## #128 — OECD status charts ordered by curation maturity

KE and KER completeness sat side by side with identical axes and disagreed on **both** x-axis and legend order, so reading one against the other meant re-reading both axes each time. Cause: `px.bar` with no `category_orders`, leaving order to DataFrame insertion order.

Since OECD status is **ordinal**, the fix isn't just a stable order but the meaningful one — `No Status → Under Development → Under Review → WPHA/WNT Endorsed`. The completeness gradient across curation maturity now reads straight off the axis, which is the point the charts exist to make:

- **KE**: Essential 66.5% → 80.1% → 98.5% → 100%
- **KER**: Essential 59.8% → 71.3% → 95.2% → 99.9%

Applied to all three completeness-by-status charts (AOP, KE, KER) plus the OECD legend on Entity Counts by OECD Status, so the whole family agrees. Property types get a fixed core → peripheral order for the same reason.

`OECD_STATUS_ORDER` was verified against the live 2026-07-01 graph — those four are the only values present (442 / 85 / 42 / 19 AOPs). Statuses missing from the list are appended by Plotly rather than dropped, so a future status still renders.

**Noted, not fixed:** `BRAND_COLORS['oecd_status']` is stale. It keys on `EAGMST Under Review`, `TFHA/WNT Endorsed`, `WNT Endorsed`, `Approved`, `Not OECD` — none of which occur — and is missing `Under Review` and `WPHA/WNT Endorsed`, which do. So two of the four statuses fall back to default colours. Left alone here to keep this PR to ordering; flagged in a code comment.

## #129 — stuck plots now time out, and concurrency is capped

`fetch` had no `AbortController`, so a request the backend never answered left the promise unsettled: skeleton up forever, `catch` never reached, no message and no Retry. The error UI already handled timeouts properly — it just could not be reached.

Two changes:

1. **45s abort**, routed into the existing timeout branch of `showErrorState()`.
2. **In-flight `/api/plot` requests capped at 4.** This addresses the cause rather than the symptom: each call runs a SPARQL query, and scrolling fast fired all ~30 at once, so the browser's per-host connection limit queued them invisibly and the tail starved — which is what produced apparently-stuck plots. Bounding it in the loader makes the wait observable to the timeout instead of opaque.

Queued plots show their skeleton immediately, so the cap doesn't read as slower feedback.

## Verification

Against a local instance on the live endpoint (41/41 plots):

**#128** — all three charts emit `categoryorder: "array"` with `categoryarray: ["No Status","Under Development","Under Review","WPHA/WNT Endorsed"]`, confirmed surviving the later `update_layout`. Legend order now identical across siblings. Verified visually.

**#129** — enqueued all 30 plots at once: 28 queued immediately, peak concurrency **4** (never exceeded), queue drained to 0, all 30 loaded, no leaked entries in `loadingPlots`. Forced the abort path with `LOAD_TIMEOUT_MS = 1`: renders "Query Timed Out" + suggestion + Retry, spinner gone. Retry at the restored 45s timeout recovers and renders the plot.

30 tests pass. Both JS files pass `node --check`.
