### PR TITLE
fix: small-multiples property-presence charts (#130)

### DIFF
--- a/plots/shared.py
+++ b/plots/shared.py
@@ -52,6 +52,7 @@ Author:
 """
 
 import os
+import math
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
@@ -1356,6 +1357,120 @@ def apply_snapshot_xaxis(fig, title: str = "Snapshot date"):
             rather than the raw ``version`` column name.
     """
     fig.update_xaxes(title_text=title, tickangle=0)
+    return fig
+
+
+def humanize_predicate_uri(uri: str) -> str:
+    """Turn an unmapped predicate URI into a readable label as a last resort.
+
+    The property-presence charts label each series from property_labels.csv.
+    When a predicate is missing from that file the old code fell back to the
+    raw URI, so e.g. 'http://purl.org/dc/terms/license' showed up verbatim as a
+    legend entry among human labels (#130). This gives a graceful fallback —
+    'License' — for any predicate that slips through, so a future gap degrades
+    to an imperfect label rather than a URL. The real fix for a known predicate
+    is still to add a curated row to property_labels.csv (correct label + type).
+    """
+    if not isinstance(uri, str) or not uri:
+        return uri
+    tail = uri.rsplit("#", 1)[-1].rsplit("/", 1)[-1]
+    tail = tail.replace("_", " ").replace("-", " ").strip()
+    return tail.title() if tail else uri
+
+
+def mask_property_prefix_zeros(df, value_cols=("count", "percentage")):
+    """Blank each property's run of leading zeros before it first appears.
+
+    Property-presence data is reindexed to a complete (version × property) grid,
+    so a property absent from early snapshots is filled with 0. Drawn as a line,
+    that reads as a value sitting at zero and then jumping — instant adoption —
+    when really the property did not exist in the data yet (#130). Masking the
+    leading zeros to NaN (with connectgaps off) makes each series start at its
+    first real point. Interior zeros — a property that genuinely dropped back to
+    none mid-history — are left intact.
+
+    Operates on a copy; the input frame (used for the CSV/raw-data export, where
+    0 is the truthful value) is not modified.
+    """
+    df = df.sort_values(["property", "version"]).reset_index(drop=True).copy()
+    for _prop, g in df.groupby("property", sort=False):
+        counts = g["count"].values
+        nz = counts > 0
+        if not nz.any():
+            continue
+        first = int(nz.argmax())  # positional index of first non-zero
+        if first > 0:
+            rows = g.index[:first]
+            for c in value_cols:
+                if c in df.columns:
+                    df.loc[rows, c] = float("nan")
+    return df
+
+
+def build_property_presence_figure(df, y_col, y_title, entity_label, percentage=False):
+    """Small-multiples property-presence figure — one panel per property.
+
+    Replaces the former single line chart that stacked up to 17 series on one
+    categorical palette with a scrolling legend (#130): no palette distinguishes
+    that many series, and the legend hid some. Here each property gets its own
+    panel with a shared y-axis, and the facet title names it, so no colour
+    legend is needed and colour stops carrying load.
+
+    Facets are ordered by property type (Essential → … → Metadata) then label,
+    so related properties sit together. `df` is expected to carry `version`,
+    `display_label`, the `y_col`, and optionally `type`.
+    """
+    props = list(df["display_label"].drop_duplicates())
+    n = len(props)
+    if n == 0:
+        return create_fallback_plot(
+            f"{entity_label} Property Presence", "No properties to display"
+        )
+
+    wrap = min(4, n)
+    n_rows = math.ceil(n / wrap)
+
+    if "type" in df.columns:
+        order_df = df[["display_label", "type"]].drop_duplicates()
+        type_rank = {t: i for i, t in enumerate(PROPERTY_TYPE_ORDER)}
+        order_df = order_df.assign(
+            _k=order_df["type"].map(lambda t: type_rank.get(t, len(type_rank)))
+        )
+        ordered = order_df.sort_values(["_k", "display_label"])["display_label"].tolist()
+    else:
+        ordered = sorted(props)
+
+    fig = px.line(
+        df,
+        x="version",
+        y=y_col,
+        color="display_label",
+        facet_col="display_label",
+        facet_col_wrap=wrap,
+        markers=True,
+        category_orders={"display_label": ordered},
+        color_discrete_sequence=BRAND_COLORS['palette'],
+    )
+    fig.update_traces(marker=dict(size=5), line=dict(width=1.5), connectgaps=False)
+    # px names each facet "display_label=<name>"; keep just the property name.
+    fig.for_each_annotation(
+        lambda a: a.update(text=a.text.split("=", 1)[-1], font=dict(size=11))
+    )
+    fig.update_xaxes(title_text="", tickangle=0, tickfont=dict(size=9), nticks=4)
+    fig.update_yaxes(title_text="", matches="y", tickfont=dict(size=9))
+    if percentage:
+        fig.update_yaxes(range=[0, 105])
+
+    fig.update_layout(
+        height=90 + n_rows * 155,
+        showlegend=False,
+        margin=dict(l=55, r=15, t=45, b=55),
+    )
+    # One shared pair of axis titles for the whole grid.
+    fig.add_annotation(text="Snapshot date", xref="paper", yref="paper",
+                       x=0.5, y=-0.08, showarrow=False, font=dict(size=12))
+    fig.add_annotation(text=y_title, xref="paper", yref="paper", x=-0.045, y=0.5,
+                       textangle=-90, showarrow=False, font=dict(size=12))
     return fig
 
 

--- a/plots/trends_plots.py
+++ b/plots/trends_plots.py
@@ -62,6 +62,8 @@ from .shared import (
     run_sparql_query, run_sparql_query_with_retry, extract_counts,
     safe_read_csv, create_fallback_plot, get_properties_for_entity,
     get_all_versions, render_plot_html, apply_snapshot_xaxis,
+    build_property_presence_figure, mask_property_prefix_zeros,
+    humanize_predicate_uri,
     ENTITY_TYPE_CLASSES, diff_entities_between_versions,
     fetch_entity_uris_by_version,
 )
@@ -2245,59 +2247,30 @@ def plot_aop_property_presence(label_file="property_labels.csv") -> tuple[str, s
 
         if not df_labels.empty:
             df = df.merge(df_labels, how="left", left_on="property", right_on="uri")
-            df["display_label"] = df["label"].fillna(df["property"])
+            # Curated label where property_labels.csv has one; otherwise a
+            # humanized last-resort label so an unmapped predicate never renders
+            # as a raw URI (#130).
+            df["display_label"] = df["label"].fillna(
+                df["property"].map(humanize_predicate_uri)
+            )
         else:
-            df["display_label"] = df["property"]
+            df["display_label"] = df["property"].map(humanize_predicate_uri)
 
         # Sort
         df["version_dt"] = pd.to_datetime(df["version"], errors="coerce")
         df = df.sort_values("version_dt")
 
-        # Cache data for CSV export
+        # Cache data for CSV export (raw 0s intact — the table's truthful value).
         _plot_data_cache['aop_property_presence_absolute'] = df.copy()
         _plot_data_cache['aop_property_presence_percentage'] = df.copy()
 
-        # Define marker shapes for visual distinction
-        marker_symbols = ['circle', 'square', 'diamond', 'triangle-up', 'cross', 'x', 'star',
-                          'pentagon', 'hexagon', 'octagon', 'triangle-down', 'triangle-left', 'triangle-right']
-
-        # Absolute presence
-        fig_abs = px.line(
-            df,
-            x="version",
-            y="count",
-            color="display_label",
-            markers=True,
-            labels={"count": "Number of AOPs", "display_label": "Property"},
-            color_discrete_sequence=BRAND_COLORS['palette']
-        )
-
-        # Apply marker shapes to traces
-        for i, trace in enumerate(fig_abs.data):
-            trace.update(marker=dict(symbol=marker_symbols[i % len(marker_symbols)], size=8))
-
-        fig_abs.update_layout(
-            margin=dict(l=50, r=20, t=50, b=50)
-        )
-
-        # Percentage presence
-        fig_delta = px.line(
-            df,
-            x="version",
-            y="percentage",
-            color="display_label",
-            markers=True,
-            labels={"percentage": "Percentage (%)", "display_label": "Property"},
-            color_discrete_sequence=BRAND_COLORS['palette']
-        )
-
-        # Apply marker shapes to traces
-        for i, trace in enumerate(fig_delta.data):
-            trace.update(marker=dict(symbol=marker_symbols[i % len(marker_symbols)], size=8))
-
-        fig_delta.update_layout(
-            margin=dict(l=50, r=20, t=50, b=50)
-        )
+        # Small multiples, one panel per property (#130). Mask leading zeros so a
+        # property's line starts when it first appears, not from a flat zero run.
+        plot_df = mask_property_prefix_zeros(df)
+        fig_abs = build_property_presence_figure(
+            plot_df, "count", "Number of AOPs", "AOP")
+        fig_delta = build_property_presence_figure(
+            plot_df, "percentage", "Percentage (%)", "AOP", percentage=True)
 
         # Cache figures for image export
         _plot_figure_cache['aop_property_presence_absolute'] = fig_abs
@@ -2419,32 +2392,28 @@ def plot_ke_property_presence(label_file="property_labels.csv") -> tuple[str, st
         df_labels = safe_read_csv(label_file, default_labels)
         if not df_labels.empty:
             df = df.merge(df_labels, how="left", left_on="property", right_on="uri")
-            df["display_label"] = df["label"].fillna(df["property"])
+            # Curated label where property_labels.csv has one; otherwise a
+            # humanized last-resort label so an unmapped predicate never renders
+            # as a raw URI (#130).
+            df["display_label"] = df["label"].fillna(
+                df["property"].map(humanize_predicate_uri)
+            )
         else:
-            df["display_label"] = df["property"]
+            df["display_label"] = df["property"].map(humanize_predicate_uri)
 
         df["version_dt"] = pd.to_datetime(df["version"], errors="coerce")
         df = df.sort_values("version_dt")
 
+        # Raw 0s intact for the CSV/raw-data export.
         _plot_data_cache['ke_property_presence_absolute'] = df.copy()
         _plot_data_cache['ke_property_presence_percentage'] = df.copy()
 
-        marker_symbols = ['circle', 'square', 'diamond', 'triangle-up', 'cross', 'x', 'star',
-                          'pentagon', 'hexagon', 'octagon', 'triangle-down', 'triangle-left', 'triangle-right']
-
-        fig_abs = px.line(df, x="version", y="count", color="display_label", markers=True,
-                          labels={"count": "Number of KEs", "display_label": "Property"},
-                          color_discrete_sequence=BRAND_COLORS['palette'])
-        for i, trace in enumerate(fig_abs.data):
-            trace.update(marker=dict(symbol=marker_symbols[i % len(marker_symbols)], size=8))
-        fig_abs.update_layout(margin=dict(l=50, r=20, t=50, b=50))
-
-        fig_delta = px.line(df, x="version", y="percentage", color="display_label", markers=True,
-                            labels={"percentage": "Percentage (%)", "display_label": "Property"},
-                            color_discrete_sequence=BRAND_COLORS['palette'])
-        for i, trace in enumerate(fig_delta.data):
-            trace.update(marker=dict(symbol=marker_symbols[i % len(marker_symbols)], size=8))
-        fig_delta.update_layout(margin=dict(l=50, r=20, t=50, b=50))
+        # Small multiples, one panel per property (#130).
+        plot_df = mask_property_prefix_zeros(df)
+        fig_abs = build_property_presence_figure(
+            plot_df, "count", "Number of KEs", "KE")
+        fig_delta = build_property_presence_figure(
+            plot_df, "percentage", "Percentage (%)", "KE", percentage=True)
 
         _plot_figure_cache['ke_property_presence_absolute'] = fig_abs
         _plot_figure_cache['ke_property_presence_percentage'] = fig_delta
@@ -2541,32 +2510,28 @@ def plot_ker_property_presence(label_file="property_labels.csv") -> tuple[str, s
         df_labels = safe_read_csv(label_file, default_labels)
         if not df_labels.empty:
             df = df.merge(df_labels, how="left", left_on="property", right_on="uri")
-            df["display_label"] = df["label"].fillna(df["property"])
+            # Curated label where property_labels.csv has one; otherwise a
+            # humanized last-resort label so an unmapped predicate never renders
+            # as a raw URI (#130).
+            df["display_label"] = df["label"].fillna(
+                df["property"].map(humanize_predicate_uri)
+            )
         else:
-            df["display_label"] = df["property"]
+            df["display_label"] = df["property"].map(humanize_predicate_uri)
 
         df["version_dt"] = pd.to_datetime(df["version"], errors="coerce")
         df = df.sort_values("version_dt")
 
+        # Raw 0s intact for the CSV/raw-data export.
         _plot_data_cache['ker_property_presence_absolute'] = df.copy()
         _plot_data_cache['ker_property_presence_percentage'] = df.copy()
 
-        marker_symbols = ['circle', 'square', 'diamond', 'triangle-up', 'cross', 'x', 'star',
-                          'pentagon', 'hexagon', 'octagon', 'triangle-down', 'triangle-left', 'triangle-right']
-
-        fig_abs = px.line(df, x="version", y="count", color="display_label", markers=True,
-                          labels={"count": "Number of KERs", "display_label": "Property"},
-                          color_discrete_sequence=BRAND_COLORS['palette'])
-        for i, trace in enumerate(fig_abs.data):
-            trace.update(marker=dict(symbol=marker_symbols[i % len(marker_symbols)], size=8))
-        fig_abs.update_layout(margin=dict(l=50, r=20, t=50, b=50))
-
-        fig_delta = px.line(df, x="version", y="percentage", color="display_label", markers=True,
-                            labels={"percentage": "Percentage (%)", "display_label": "Property"},
-                            color_discrete_sequence=BRAND_COLORS['palette'])
-        for i, trace in enumerate(fig_delta.data):
-            trace.update(marker=dict(symbol=marker_symbols[i % len(marker_symbols)], size=8))
-        fig_delta.update_layout(margin=dict(l=50, r=20, t=50, b=50))
+        # Small multiples, one panel per property (#130).
+        plot_df = mask_property_prefix_zeros(df)
+        fig_abs = build_property_presence_figure(
+            plot_df, "count", "Number of KERs", "KER")
+        fig_delta = build_property_presence_figure(
+            plot_df, "percentage", "Percentage (%)", "KER", percentage=True)
 
         _plot_figure_cache['ker_property_presence_absolute'] = fig_abs
         _plot_figure_cache['ker_property_presence_percentage'] = fig_delta
@@ -2663,32 +2628,28 @@ def plot_stressor_property_presence(label_file="property_labels.csv") -> tuple[s
         df_labels = safe_read_csv(label_file, default_labels)
         if not df_labels.empty:
             df = df.merge(df_labels, how="left", left_on="property", right_on="uri")
-            df["display_label"] = df["label"].fillna(df["property"])
+            # Curated label where property_labels.csv has one; otherwise a
+            # humanized last-resort label so an unmapped predicate never renders
+            # as a raw URI (#130).
+            df["display_label"] = df["label"].fillna(
+                df["property"].map(humanize_predicate_uri)
+            )
         else:
-            df["display_label"] = df["property"]
+            df["display_label"] = df["property"].map(humanize_predicate_uri)
 
         df["version_dt"] = pd.to_datetime(df["version"], errors="coerce")
         df = df.sort_values("version_dt")
 
+        # Raw 0s intact for the CSV/raw-data export.
         _plot_data_cache['stressor_property_presence_absolute'] = df.copy()
         _plot_data_cache['stressor_property_presence_percentage'] = df.copy()
 
-        marker_symbols = ['circle', 'square', 'diamond', 'triangle-up', 'cross', 'x', 'star',
-                          'pentagon', 'hexagon', 'octagon', 'triangle-down', 'triangle-left', 'triangle-right']
-
-        fig_abs = px.line(df, x="version", y="count", color="display_label", markers=True,
-                          labels={"count": "Number of Stressors", "display_label": "Property"},
-                          color_discrete_sequence=BRAND_COLORS['palette'])
-        for i, trace in enumerate(fig_abs.data):
-            trace.update(marker=dict(symbol=marker_symbols[i % len(marker_symbols)], size=8))
-        fig_abs.update_layout(margin=dict(l=50, r=20, t=50, b=50))
-
-        fig_delta = px.line(df, x="version", y="percentage", color="display_label", markers=True,
-                            labels={"percentage": "Percentage (%)", "display_label": "Property"},
-                            color_discrete_sequence=BRAND_COLORS['palette'])
-        for i, trace in enumerate(fig_delta.data):
-            trace.update(marker=dict(symbol=marker_symbols[i % len(marker_symbols)], size=8))
-        fig_delta.update_layout(margin=dict(l=50, r=20, t=50, b=50))
+        # Small multiples, one panel per property (#130).
+        plot_df = mask_property_prefix_zeros(df)
+        fig_abs = build_property_presence_figure(
+            plot_df, "count", "Number of Stressors", "Stressor")
+        fig_delta = build_property_presence_figure(
+            plot_df, "percentage", "Percentage (%)", "Stressor", percentage=True)
 
         _plot_figure_cache['stressor_property_presence_absolute'] = fig_abs
         _plot_figure_cache['stressor_property_presence_percentage'] = fig_delta

--- a/property_labels.csv
+++ b/property_labels.csv
@@ -43,3 +43,4 @@ http://edamontology.org/data_2042,Empirical Support,Assessment,KER
 http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C71478,Uncertainty,Assessment,KER
 http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C80263,Biological Plausibility,Assessment,KER
 http://aopkb.org/aop_ontology#has_chemical_entity,Chemical Entity,Content,Stressor
+http://purl.org/dc/terms/license,License,Metadata,AOP

--- a/static/data/methodology_notes.json
+++ b/static/data/methodology_notes.json
@@ -308,7 +308,7 @@
     },
     "ke_property_presence": {
         "title": "KE Property Presence Over Time",
-        "description": "Tracks which metadata properties are present in Key Events over time. Identifies completeness patterns and annotation trends. Uses marker shapes for visual distinction between property lines.",
+        "description": "Tracks which metadata properties are present in Key Events over time. Identifies completeness patterns and annotation trends. Each property is shown in its own small-multiple panel.",
         "data_source": "Properties are defined in property_labels.csv filtered for KE entity type. SPARQL queries check property presence across all Key Events in each version using GROUP_CONCAT aggregation.",
         "limitations": "Properties always present (100%) are excluded for clarity. Measures presence of each property, not quality or accuracy of the values stored. Trend data covers only the published RDF release versions available in the SPARQL endpoint; the AOP-Wiki knowledge base predates the earliest RDF release, so earlier activity is not captured.",
         "queries": [
@@ -324,7 +324,7 @@
     },
     "ker_property_presence": {
         "title": "KER Property Presence Over Time",
-        "description": "Tracks which metadata properties are present in Key Event Relationships over time. Monitors evidence and annotation quality across versions. Uses marker shapes for visual distinction between property lines.",
+        "description": "Tracks which metadata properties are present in Key Event Relationships over time. Monitors evidence and annotation quality across versions. Each property is shown in its own small-multiple panel.",
         "data_source": "Properties are defined in property_labels.csv filtered for KER entity type. SPARQL queries check property presence across all KERs in each version using GROUP_CONCAT aggregation.",
         "limitations": "Properties always present (100%) are excluded for clarity. Measures presence of each property, not the strength or quality of evidence recorded. Trend data covers only the published RDF release versions available in the SPARQL endpoint; the AOP-Wiki knowledge base predates the earliest RDF release, so earlier activity is not captured.",
         "queries": [
@@ -340,7 +340,7 @@
     },
     "stressor_property_presence": {
         "title": "Stressor Property Presence Over Time",
-        "description": "Tracks which metadata properties are present in Stressors over time. Identifies documentation patterns and completeness trends for stressor entities. Uses marker shapes for visual distinction.",
+        "description": "Tracks which metadata properties are present in Stressors over time. Identifies documentation patterns and completeness trends for stressor entities. Each property is shown in its own small-multiple panel.",
         "data_source": "Properties are defined in property_labels.csv filtered for Stressor entity type. SPARQL queries check property presence across all Stressors in each version using GROUP_CONCAT aggregation.",
         "limitations": "Properties always present (100%) are excluded for clarity. Stressors are identified by the NCI Thesaurus type (nci:C54571), which may not capture all stressor-related entities in the knowledge base. Trend data covers only the published RDF release versions available in the SPARQL endpoint; the AOP-Wiki knowledge base predates the earliest RDF release, so earlier activity is not captured.",
         "queries": [

--- a/templates/trends.html
+++ b/templates/trends.html
@@ -45,7 +45,7 @@
 
 
     <!-- AOP Property Presence -->
-    <div class="plot-box" id="aop-property-presence">
+    <div class="plot-box full-width" id="aop-property-presence">
         <div class="plot-header">
             <h3>AOP Property Presence Over Time</h3>
             <div style="display: flex; gap: 10px; align-items: center;">
@@ -87,7 +87,7 @@
     </div>
 
     <!-- Key Event Property Presence -->
-    <div class="plot-box" id="ke-property-presence">
+    <div class="plot-box full-width" id="ke-property-presence">
         <div class="plot-header">
             <h3>Key Event Property Presence Over Time</h3>
             <div style="display: flex; gap: 10px; align-items: center;">
@@ -112,7 +112,7 @@
         </div>
         <p class="plot-description">
             Tracks which metadata properties are present in Key Events over time. Identifies completeness patterns and annotation trends.
-            Uses marker shapes for visual distinction.
+            Each property is shown in its own panel.
         </p>
         {{ methodology_note(methodology_notes, 'ke_property_presence') }}
         <div class="abs">
@@ -129,7 +129,7 @@
     </div>
 
     <!-- Key Event Relationship Property Presence -->
-    <div class="plot-box" id="ker-property-presence">
+    <div class="plot-box full-width" id="ker-property-presence">
         <div class="plot-header">
             <h3>Key Event Relationship Property Presence Over Time</h3>
             <div style="display: flex; gap: 10px; align-items: center;">
@@ -154,7 +154,7 @@
         </div>
         <p class="plot-description">
             Tracks which metadata properties are present in Key Event Relationships over time. Monitors evidence and annotation quality.
-            Uses marker shapes for visual distinction.
+            Each property is shown in its own panel.
         </p>
         {{ methodology_note(methodology_notes, 'ker_property_presence') }}
         <div class="abs">
@@ -171,7 +171,7 @@
     </div>
 
     <!-- Stressor Property Presence -->
-    <div class="plot-box" id="stressor-property-presence">
+    <div class="plot-box full-width" id="stressor-property-presence">
         <div class="plot-header">
             <h3>Stressor Property Presence Over Time</h3>
             <div style="display: flex; gap: 10px; align-items: center;">
@@ -196,7 +196,7 @@
         </div>
         <p class="plot-description">
             Tracks which metadata properties are present in Stressors over time. Identifies documentation patterns and completeness trends.
-            Uses marker shapes for visual distinction.
+            Each property is shown in its own panel.
         </p>
         {{ methodology_note(methodology_notes, 'stressor_property_presence') }}
         <div class="abs">


### PR DESCRIPTION
Rebuilds the four property-presence trends charts as small multiples, and fixes the two correctness defects filed alongside. All of #130.

## The restructure

Each chart stacked up to **17 series** on one categorical palette — no palette distinguishes that many, and the legend scrolled so some series were hidden. Now **one panel per property** (px facet, shared y-axis, facet title names each property), so colour carries no load and nothing is hidden. Facets are ordered by property type → label, so related properties group together. The four cards are promoted to full width to give the grid room.

Chosen over "split by type" and "keep-one-chart + legend fix" because it removes colour ambiguity entirely rather than relying on hover.

## Two correctness fixes

**Raw URI leak.** `http://purl.org/dc/terms/license` — present on 523/588 AOPs — was missing from `property_labels.csv`, so it fell through to the raw URI as its legend label. I confirmed against the live endpoint it's the *only* unmapped predicate across all four entities. Added a curated row (`License`, Metadata), and hardened the fallback: `humanize_predicate_uri()` turns any future unmapped predicate into a readable label (`License`) instead of a URL.

**Lines ramping from zero.** A property absent from early snapshots was filled with 0 and drawn as a flat line that jumps — reading as instant adoption when the property simply didn't exist yet. `mask_property_prefix_zeros()` blanks each series' leading zeros so it starts at first real data; interior zeros (a property that genuinely dropped to none) are kept. The mask applies **only to the figure** — the CSV/raw-data export keeps the truthful 0s.

## Refactor

All four functions now share `build_property_presence_figure()` and `mask_property_prefix_zeros()` in `shared.py`, replacing four near-identical figure blocks (net −108 lines of duplication in `trends_plots.py`).

## Verification

Local instance on the live endpoint (41/41):

- **Panels**: AOP 17, KE 13, KER 8, Stressor 2 — all render `success: true`, no raw-URI leak in any of the eight figures.
- **License**: series has 24 leading nulls, starts at 2024-04-01 (value 373 → 523), i.e. the line begins at first real data instead of ramping from zero.
- **Percentage toggle**: switches views, y-axis shared at 0–105.
- **Exports**: CSV / PNG (kaleido, faceted, 91 KB) / SVG all 200. CSV retains the raw 0s for License before 2024 — confirming the mask is figure-only.
- **CSV rows** verified truthful; raw-data endpoint 200.
- 30 tests pass; methodology-lint clean (55 entries, 0 failures); JSON valid.

Card descriptions and methodology notes updated — the old "marker shapes for visual distinction" no longer applies.
