### PR TITLE
fix: accessibility and interaction polish (#131)

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -67,6 +67,46 @@ body.site-body {
     min-height: 100vh;
 }
 
+/* Section-nav anchors scroll smoothly; disabled under reduced-motion below. */
+html {
+    scroll-behavior: smooth;
+}
+
+/* ==========================================================================
+   Accessibility: visible keyboard focus + reduced motion (#131)
+   ========================================================================== */
+
+/* One visible focus ring for keyboard users on every interactive element.
+   :focus-visible keeps it off pointer clicks. Before this, the only :focus
+   rules set outline:none with no replacement, so keyboard focus was invisible. */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible,
+[tabindex]:focus-visible {
+    outline: 3px solid var(--color-cta);
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+/* Honour the OS "reduce motion" preference: near-instant transitions and
+   animations, and no smooth scroll. */
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
+    }
+}
+
 header {
     background-color: var(--color-nav-bg);
     padding: 20px;
@@ -146,6 +186,10 @@ input[type="text"], input[type="file"] {
     cursor: pointer;
     font-size: 14px;
     transition: background-color 0.3s ease;
+    /* Section-nav uses <a> elements for these; keep them looking like buttons. */
+    display: inline-block;
+    text-decoration: none;
+    text-align: center;
 }
 
 .nav-button:hover {
@@ -1218,7 +1262,11 @@ footer img {
 }
 
 .main-nav .nav-links .nav-link:hover {
-    color: var(--color-nav-hover);
+    /* Stay white and underline instead of turning magenta: #E6007E on the navy
+       nav is only 3.13:1, i.e. hovering made the label harder to read (#131). */
+    color: var(--color-nav-text);
+    text-decoration: underline;
+    text-underline-offset: 4px;
     background: transparent;
     transform: none;
     box-shadow: none;

--- a/static/js/lazy-loading.js
+++ b/static/js/lazy-loading.js
@@ -5,6 +5,15 @@
  * from 28+ seconds to under 2 seconds by loading plots on-demand.
  */
 
+// Verbose per-plot tracing, off by default so a normal page load is quiet
+// (was ~52 console.log lines per /snapshot, #131). Enable from devtools with
+//   localStorage.setItem('plotDebug', '1')
+// then reload. Warnings and errors always log.
+const PLOT_DEBUG = (() => {
+    try { return localStorage.getItem('plotDebug') === '1'; } catch (e) { return false; }
+})();
+function dbg(...args) { if (PLOT_DEBUG) console.log(...args); }
+
 class PlotLazyLoader {
     constructor() {
         this.loadedPlots = new Set();
@@ -16,7 +25,7 @@ class PlotLazyLoader {
     }
 
     init() {
-        console.log("PlotLazyLoader: Initializing lazy loading system");
+        dbg("PlotLazyLoader: Initializing lazy loading system");
 
         // Set up Intersection Observer for lazy loading
         this.observer = new IntersectionObserver(
@@ -30,10 +39,10 @@ class PlotLazyLoader {
 
         // Observe all lazy plot containers
         const lazyPlots = document.querySelectorAll('.lazy-plot');
-        console.log(`PlotLazyLoader: Found ${lazyPlots.length} lazy-plot containers`);
+        dbg(`PlotLazyLoader: Found ${lazyPlots.length} lazy-plot containers`);
 
         lazyPlots.forEach(element => {
-            console.log(`PlotLazyLoader: Observing plot: ${element.dataset.plotName}`);
+            dbg(`PlotLazyLoader: Observing plot: ${element.dataset.plotName}`);
             this.observer.observe(element);
         });
 
@@ -80,10 +89,10 @@ class PlotLazyLoader {
      */
     loadPlot(element) {
         const plotName = element.dataset.plotName;
-        console.log(`PlotLazyLoader: Attempting to load plot: ${plotName}`);
+        dbg(`PlotLazyLoader: Attempting to load plot: ${plotName}`);
 
         if (this.loadedPlots.has(plotName) || this.loadingPlots.has(plotName)) {
-            console.log(`PlotLazyLoader: Plot ${plotName} already loaded or loading, skipping`);
+            dbg(`PlotLazyLoader: Plot ${plotName} already loaded or loading, skipping`);
             return;
         }
 
@@ -115,7 +124,7 @@ class PlotLazyLoader {
 
     async fetchPlot(element) {
         const plotName = element.dataset.plotName;
-        console.log(`PlotLazyLoader: Starting load for plot: ${plotName}`);
+        dbg(`PlotLazyLoader: Starting load for plot: ${plotName}`);
 
         // Without an abort signal a hung backend leaves the promise unsettled
         // forever: the spinner stays up, the catch below never runs, and the
@@ -133,12 +142,12 @@ class PlotLazyLoader {
             const url = qs ? `/api/plot/${plotName}?${qs}` : `/api/plot/${plotName}`;
 
             // Fetch plot data
-            console.log(`PlotLazyLoader: Fetching data for plot: ${plotName} (${url})`);
+            dbg(`PlotLazyLoader: Fetching data for plot: ${plotName} (${url})`);
             const response = await fetch(url, { signal: controller.signal });
-            console.log(`PlotLazyLoader: Response status for ${plotName}: ${response.status}`);
+            dbg(`PlotLazyLoader: Response status for ${plotName}: ${response.status}`);
 
             const data = await response.json();
-            console.log(`PlotLazyLoader: Response data for ${plotName}:`, {
+            dbg(`PlotLazyLoader: Response data for ${plotName}:`, {
                 success: data.success,
                 hasHtml: !!data.html,
                 htmlLength: data.html?.length || 0
@@ -146,42 +155,51 @@ class PlotLazyLoader {
 
             if (data.success) {
                 // Replace skeleton with actual plot
-                console.log(`PlotLazyLoader: Rendering plot ${plotName}`);
+                dbg(`PlotLazyLoader: Rendering plot ${plotName}`);
                 element.innerHTML = data.html;
                 this.loadedPlots.add(plotName);
 
-                // Execute any script tags in the inserted HTML
+                // Run the inline init scripts from the fetched HTML by
+                // re-injecting them as fresh <script> elements, rather than
+                // eval() (#131). innerHTML-inserted <script> tags don't execute
+                // on their own; a re-injected one runs normally in global scope,
+                // which is exactly what Plotly's `Plotly.newPlot(<id>, …)` init
+                // needs. (This removes the eval; it does not by itself enable a
+                // strict CSP — inline scripts still run. That's a separate task.)
                 const scripts = element.querySelectorAll('script');
-                scripts.forEach(script => {
-                    if (script.innerHTML) {
-                        try {
-                            console.log(`PlotLazyLoader: Executing script for ${plotName}`);
-                            eval(script.innerHTML);
-                        } catch (error) {
-                            console.error(`PlotLazyLoader: Script execution error for ${plotName}:`, error);
-                        }
+                scripts.forEach(oldScript => {
+                    if (!oldScript.textContent) return;
+                    try {
+                        dbg(`PlotLazyLoader: Executing script for ${plotName}`);
+                        const s = document.createElement('script');
+                        if (oldScript.type) s.type = oldScript.type;
+                        s.textContent = oldScript.textContent;
+                        document.body.appendChild(s);
+                        document.body.removeChild(s);
+                    } catch (error) {
+                        console.error(`PlotLazyLoader: Script execution error for ${plotName}:`, error);
                     }
                 });
 
                 // Check if Plotly is available
-                console.log(`PlotLazyLoader: Plotly available: ${!!window.Plotly}`);
+                dbg(`PlotLazyLoader: Plotly available: ${!!window.Plotly}`);
 
                 // Trigger Plotly resize if needed
                 if (window.Plotly) {
                     const plotDiv = element.querySelector('.plotly-graph-div');
                     if (plotDiv) {
-                        console.log(`PlotLazyLoader: Resizing Plotly plot: ${plotName}`);
+                        dbg(`PlotLazyLoader: Resizing Plotly plot: ${plotName}`);
                         setTimeout(() => {
                             window.Plotly.Plots.resize(plotDiv);
                         }, 100);
                     } else {
-                        console.log(`PlotLazyLoader: No plotly-graph-div found for: ${plotName}`);
+                        dbg(`PlotLazyLoader: No plotly-graph-div found for: ${plotName}`);
                     }
                 } else {
                     console.warn(`PlotLazyLoader: Plotly not available for plot: ${plotName}`);
                 }
 
-                console.log(`PlotLazyLoader: Successfully loaded plot: ${plotName}`);
+                dbg(`PlotLazyLoader: Successfully loaded plot: ${plotName}`);
             } else {
                 console.error(`PlotLazyLoader: Plot ${plotName} failed:`, data.error);
                 this.showErrorState(element, data.error);

--- a/static/js/raw-data-tables.js
+++ b/static/js/raw-data-tables.js
@@ -16,6 +16,7 @@ async function toggleDataTable(plotName) {
     if (content.style.display === 'none' || content.style.display === '') {
         content.style.display = 'block';
         button.textContent = 'Hide Raw Data';
+        button.setAttribute('aria-expanded', 'true');
 
         if (!content.dataset.loaded) {
             content.innerHTML = '<div class="data-table-loading">Loading data...</div>';
@@ -45,6 +46,7 @@ async function toggleDataTable(plotName) {
     } else {
         content.style.display = 'none';
         button.textContent = 'Show Raw Data';
+        button.setAttribute('aria-expanded', 'false');
     }
 }
 
@@ -80,5 +82,6 @@ document.addEventListener('version-changed', function() {
     });
     document.querySelectorAll('.data-table-toggle').forEach(function(btn) {
         btn.textContent = 'Show Raw Data';
+        btn.setAttribute('aria-expanded', 'false');
     });
 });

--- a/templates/latest.html
+++ b/templates/latest.html
@@ -29,13 +29,13 @@
     </div>
 </div>
 <nav class="snapshot-section-nav" aria-label="Jump to section">
-    <button class="nav-button nav-button--compact" onclick="document.getElementById('database-state').scrollIntoView({behavior:'smooth'});">Database State</button>
-    <button class="nav-button nav-button--compact" onclick="document.getElementById('network-analysis').scrollIntoView({behavior:'smooth'});">Network Analysis</button>
-    <button class="nav-button nav-button--compact" onclick="document.getElementById('ke-analysis').scrollIntoView({behavior:'smooth'});">Key Event Analysis</button>
-    <button class="nav-button nav-button--compact" onclick="document.getElementById('breakdown-analysis').scrollIntoView({behavior:'smooth'});">Breakdown Analysis</button>
-    <button class="nav-button nav-button--compact" onclick="document.getElementById('coverage-analysis').scrollIntoView({behavior:'smooth'});">Coverage Analysis</button>
-    <button class="nav-button nav-button--compact" onclick="document.getElementById('ke-reuse').scrollIntoView({behavior:'smooth'});">KE Reuse</button>
-    <button class="nav-button nav-button--compact" onclick="document.getElementById('data-quality').scrollIntoView({behavior:'smooth'});">Data Quality</button>
+    <a class="nav-button nav-button--compact" href="#database-state">Database State</a>
+    <a class="nav-button nav-button--compact" href="#network-analysis">Network Analysis</a>
+    <a class="nav-button nav-button--compact" href="#ke-analysis">Key Event Analysis</a>
+    <a class="nav-button nav-button--compact" href="#breakdown-analysis">Breakdown Analysis</a>
+    <a class="nav-button nav-button--compact" href="#coverage-analysis">Coverage Analysis</a>
+    <a class="nav-button nav-button--compact" href="#ke-reuse">KE Reuse</a>
+    <a class="nav-button nav-button--compact" href="#data-quality">Data Quality</a>
 </nav>
 {% endblock %}
 

--- a/templates/macros/data_table.html
+++ b/templates/macros/data_table.html
@@ -1,6 +1,6 @@
 {% macro data_table_toggle(plot_name) %}
 <div class="data-table-container" data-table-for="{{ plot_name }}">
-    <button class="data-table-toggle" onclick="toggleDataTable('{{ plot_name }}')">
+    <button class="data-table-toggle" onclick="toggleDataTable('{{ plot_name }}')" aria-expanded="false">
         Show Raw Data
     </button>
     <div class="data-table-content" style="display:none;"></div>

--- a/templates/trends_page.html
+++ b/templates/trends_page.html
@@ -34,13 +34,13 @@
     </div>
 </div>
 <nav class="snapshot-section-nav" aria-label="Jump to section">
-    <button class="nav-button nav-button--compact" onclick="document.getElementById('main-trends').scrollIntoView({behavior:'smooth'});">Main Trends</button>
-    <button class="nav-button nav-button--compact" onclick="document.getElementById('entity-completeness').scrollIntoView({behavior:'smooth'});">Completeness</button>
-    <button class="nav-button nav-button--compact" onclick="document.getElementById('coverage-growth').scrollIntoView({behavior:'smooth'});">Coverage Growth</button>
-    <button class="nav-button nav-button--compact" onclick="document.getElementById('network-connectivity').scrollIntoView({behavior:'smooth'});">Connectivity</button>
-    <button class="nav-button nav-button--compact" onclick="document.getElementById('authors').scrollIntoView({behavior:'smooth'});">Authors & Lifetime</button>
-    <button class="nav-button nav-button--compact" onclick="document.getElementById('ke-components').scrollIntoView({behavior:'smooth'});">KE Components &amp; Annotations</button>
-    <button class="nav-button nav-button--compact" onclick="document.getElementById('database-churn').scrollIntoView({behavior:'smooth'});">Churn</button>
+    <a class="nav-button nav-button--compact" href="#main-trends">Main Trends</a>
+    <a class="nav-button nav-button--compact" href="#entity-completeness">Completeness</a>
+    <a class="nav-button nav-button--compact" href="#coverage-growth">Coverage Growth</a>
+    <a class="nav-button nav-button--compact" href="#network-connectivity">Connectivity</a>
+    <a class="nav-button nav-button--compact" href="#authors">Authors & Lifetime</a>
+    <a class="nav-button nav-button--compact" href="#ke-components">KE Components &amp; Annotations</a>
+    <a class="nav-button nav-button--compact" href="#database-churn">Churn</a>
 </nav>
 {% endblock %}
 


### PR DESCRIPTION
Accessibility and interaction polish — all of #131. No behaviour change to plots; several changes to how keyboard, screen-reader and reduced-motion users experience the page.

## Changes

**Visible keyboard focus.** The only `:focus` rules in the app set `outline: none` with no replacement, so keyboard focus was invisible on every button, link, tab and control. Adds a `:focus-visible` ring (3px CTA outline, 2px offset) across all interactive elements. `:focus-visible` keeps it off pointer clicks.

**Reduced motion.** Adds a `prefers-reduced-motion: reduce` block that collapses transitions/animations to ~instant and disables smooth scroll for users who ask for it — previously honoured nowhere.

**Section nav as links.** The 7 (snapshot) + 7 (trends) jump controls used `<button onclick="…scrollIntoView({behavior:'smooth'})">`. Replaced with `<a href="#id">`, so they work without JS, are copy-linkable, set the URL hash, and honour reduced motion via CSS `scroll-behavior` (the smooth scroll is now CSS, gated by the media query above). `.section-block` already carries `scroll-margin-top` for the sticky bar, so anchors land below it.

**Nav hover contrast.** `:hover` turned nav links magenta — `#E6007E` on the navy nav is **3.13:1**, i.e. hovering made the label *harder* to read than its resting white. Now stays white and underlines.

**`aria-expanded` on the raw-data toggle.** Added to the macro, kept in sync in JS (open → `true`, close/version-change → `false`). The label already swapped Show/Hide.

**Quiet console.** ~52 `console.log` lines per `/snapshot` load are now gated behind a `dbg()` helper (enable in devtools with `localStorage.setItem('plotDebug','1')`). Warnings and errors still log unconditionally.

**Removed `eval()`.** Plot init scripts from fetched HTML are executed by re-injecting them as fresh `<script>` elements rather than `eval(script.innerHTML)`. Behaviour is identical for Plotly's inline `newPlot` init. **Scope note:** this removes the `eval` specifically; it does **not** by itself establish a strict CSP, since inline scripts still run — a real CSP needs a `newPlot`-with-JSON refactor and is out of scope here. Flagged because I said I'd scope the CSP question separately rather than fold it in.

## Verification

Local instance on the live endpoint (41/41):

- **Plots still render** through the new re-injection path (confirmed a `.js-plotly-plot` present after load) — the `eval` swap is behaviour-preserving.
- **Console quiet by default** (0 `PlotLazyLoader` messages on load); `plotDebug=1` re-enables all 52. 
- **`aria-expanded`** flips `false → true → false` across open/close; label tracks.
- **Section nav** renders 7 anchors, first `href="#database-state"`; clicking sets the URL hash and jumps.
- **CSSOM checks**: `:focus-visible` rule present with `outline: 3px solid var(--color-cta)`; `prefers-reduced-motion` block present; `html { scroll-behavior: smooth }` present; `.nav-link:hover` carries `text-decoration: underline`.
- 30 tests pass; both JS files pass `node --check`.

**Not verified here:** the focus ring under live keyboard Tab — synthetic Tab is captured by the browser chrome in this automation environment, so I verified the rule via the CSSOM instead (`:focus-visible` semantics are browser-native). Also unverified: **mobile (<768px)** — window resize is not honoured in this environment.
