### PR TITLE
fix: single property-presence chart (colour+shape) + test findings

### DIFF
--- a/plots/shared.py
+++ b/plots/shared.py
@@ -52,7 +52,6 @@ Author:
 """
 
 import os
-import math
 import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
@@ -1407,28 +1406,36 @@ def mask_property_prefix_zeros(df, value_cols=("count", "percentage")):
     return df
 
 
+# Enough distinct marker glyphs that, paired with the colour palette, every
+# series in a property-presence chart is uniquely identified: the palette has
+# 11 colours and this has 13 symbols, so the (colour, symbol) pair only repeats
+# after lcm(11,13)=143 series — far more than any entity's property count.
+_MARKER_SYMBOLS = [
+    'circle', 'square', 'diamond', 'triangle-up', 'cross', 'x', 'star',
+    'pentagon', 'hexagon', 'octagon', 'triangle-down', 'triangle-left',
+    'triangle-right',
+]
+
+
 def build_property_presence_figure(df, y_col, y_title, entity_label, percentage=False):
-    """Small-multiples property-presence figure — one panel per property.
+    """Single property-presence line chart, one series per property.
 
-    Replaces the former single line chart that stacked up to 17 series on one
-    categorical palette with a scrolling legend (#130): no palette distinguishes
-    that many series, and the legend hid some. Here each property gets its own
-    panel with a shared y-axis, and the facet title names it, so no colour
-    legend is needed and colour stops carrying load.
+    Every property is a line distinguished by BOTH colour and marker shape, so
+    the ~17 series stay tellable apart even where the 11-colour palette repeats
+    (#130). The legend sits below the plot and wraps, so no series is hidden
+    behind a scrollbar the way the old in-plot legend was.
 
-    Facets are ordered by property type (Essential → … → Metadata) then label,
-    so related properties sit together. `df` is expected to carry `version`,
-    `display_label`, the `y_col`, and optionally `type`.
+    Series are ordered by property type (Essential → … → Metadata) then label,
+    so related properties group in the legend. `df` is expected to carry
+    `version`, `display_label`, the `y_col`, and optionally `type`. Callers pass
+    a frame whose leading zeros are already masked (see
+    mask_property_prefix_zeros) so lines start when a property first appears.
     """
     props = list(df["display_label"].drop_duplicates())
-    n = len(props)
-    if n == 0:
+    if not props:
         return create_fallback_plot(
             f"{entity_label} Property Presence", "No properties to display"
         )
-
-    wrap = min(4, n)
-    n_rows = math.ceil(n / wrap)
 
     if "type" in df.columns:
         order_df = df[["display_label", "type"]].drop_duplicates()
@@ -1445,32 +1452,37 @@ def build_property_presence_figure(df, y_col, y_title, entity_label, percentage=
         x="version",
         y=y_col,
         color="display_label",
-        facet_col="display_label",
-        facet_col_wrap=wrap,
         markers=True,
         category_orders={"display_label": ordered},
         color_discrete_sequence=BRAND_COLORS['palette'],
+        labels={y_col: y_title, "display_label": "Property"},
     )
-    fig.update_traces(marker=dict(size=5), line=dict(width=1.5), connectgaps=False)
-    # px names each facet "display_label=<name>"; keep just the property name.
-    fig.for_each_annotation(
-        lambda a: a.update(text=a.text.split("=", 1)[-1], font=dict(size=11))
-    )
-    fig.update_xaxes(title_text="", tickangle=0, tickfont=dict(size=9), nticks=4)
-    fig.update_yaxes(title_text="", matches="y", tickfont=dict(size=9))
+    # Give each trace its own marker shape, in the legend's (type→label) order.
+    for i, trace in enumerate(fig.data):
+        trace.update(
+            marker=dict(symbol=_MARKER_SYMBOLS[i % len(_MARKER_SYMBOLS)], size=7),
+            line=dict(width=1.5),
+            connectgaps=False,
+        )
+
+    apply_snapshot_xaxis(fig)
+    fig.update_yaxes(title_text=y_title)
     if percentage:
         fig.update_yaxes(range=[0, 105])
 
     fig.update_layout(
-        height=90 + n_rows * 155,
-        showlegend=False,
-        margin=dict(l=55, r=15, t=45, b=55),
+        # Horizontal legend below the plot: it wraps to as many rows as needed,
+        # so all series stay visible instead of scrolling inside the plot.
+        legend=dict(
+            orientation="h",
+            yanchor="top", y=-0.25,
+            xanchor="left", x=0,
+            font=dict(size=10),
+            title_text="",
+        ),
+        margin=dict(l=55, r=20, t=40, b=140),
+        height=560,
     )
-    # One shared pair of axis titles for the whole grid.
-    fig.add_annotation(text="Snapshot date", xref="paper", yref="paper",
-                       x=0.5, y=-0.08, showarrow=False, font=dict(size=12))
-    fig.add_annotation(text=y_title, xref="paper", yref="paper", x=-0.045, y=0.5,
-                       textangle=-90, showarrow=False, font=dict(size=12))
     return fig
 
 

--- a/static/data/methodology_notes.json
+++ b/static/data/methodology_notes.json
@@ -308,7 +308,7 @@
     },
     "ke_property_presence": {
         "title": "KE Property Presence Over Time",
-        "description": "Tracks which metadata properties are present in Key Events over time. Identifies completeness patterns and annotation trends. Each property is shown in its own small-multiple panel.",
+        "description": "Tracks which metadata properties are present in Key Events over time. Identifies completeness patterns and annotation trends. Each property is a line, distinguished by colour and marker shape.",
         "data_source": "Properties are defined in property_labels.csv filtered for KE entity type. SPARQL queries check property presence across all Key Events in each version using GROUP_CONCAT aggregation.",
         "limitations": "Properties always present (100%) are excluded for clarity. Measures presence of each property, not quality or accuracy of the values stored. Trend data covers only the published RDF release versions available in the SPARQL endpoint; the AOP-Wiki knowledge base predates the earliest RDF release, so earlier activity is not captured.",
         "queries": [
@@ -324,7 +324,7 @@
     },
     "ker_property_presence": {
         "title": "KER Property Presence Over Time",
-        "description": "Tracks which metadata properties are present in Key Event Relationships over time. Monitors evidence and annotation quality across versions. Each property is shown in its own small-multiple panel.",
+        "description": "Tracks which metadata properties are present in Key Event Relationships over time. Monitors evidence and annotation quality across versions. Each property is a line, distinguished by colour and marker shape.",
         "data_source": "Properties are defined in property_labels.csv filtered for KER entity type. SPARQL queries check property presence across all KERs in each version using GROUP_CONCAT aggregation.",
         "limitations": "Properties always present (100%) are excluded for clarity. Measures presence of each property, not the strength or quality of evidence recorded. Trend data covers only the published RDF release versions available in the SPARQL endpoint; the AOP-Wiki knowledge base predates the earliest RDF release, so earlier activity is not captured.",
         "queries": [
@@ -340,7 +340,7 @@
     },
     "stressor_property_presence": {
         "title": "Stressor Property Presence Over Time",
-        "description": "Tracks which metadata properties are present in Stressors over time. Identifies documentation patterns and completeness trends for stressor entities. Each property is shown in its own small-multiple panel.",
+        "description": "Tracks which metadata properties are present in Stressors over time. Identifies documentation patterns and completeness trends for stressor entities. Each property is a line, distinguished by colour and marker shape.",
         "data_source": "Properties are defined in property_labels.csv filtered for Stressor entity type. SPARQL queries check property presence across all Stressors in each version using GROUP_CONCAT aggregation.",
         "limitations": "Properties always present (100%) are excluded for clarity. Stressors are identified by the NCI Thesaurus type (nci:C54571), which may not capture all stressor-related entities in the knowledge base. Trend data covers only the published RDF release versions available in the SPARQL endpoint; the AOP-Wiki knowledge base predates the earliest RDF release, so earlier activity is not captured.",
         "queries": [

--- a/static/js/download-dropdown.js
+++ b/static/js/download-dropdown.js
@@ -46,8 +46,17 @@
             });
     }
 
+    // event.target is normally an Element, but a synthetic event can target
+    // document/window, which have no .closest(). Guard so a stray event can't
+    // throw out of these global listeners.
+    function closestOn(target, selector) {
+        return target && typeof target.closest === 'function'
+            ? target.closest(selector)
+            : null;
+    }
+
     document.addEventListener('click', function (event) {
-        var toggle = event.target.closest('.download-dropdown .dropdown-toggle');
+        var toggle = closestOn(event.target, '.download-dropdown .dropdown-toggle');
 
         if (toggle) {
             event.preventDefault();
@@ -65,7 +74,7 @@
 
     document.addEventListener('keydown', function (event) {
         if (event.key !== 'Escape') return;
-        var wrapper = event.target.closest('.download-dropdown');
+        var wrapper = closestOn(event.target, '.download-dropdown');
         closeAll(null);
         if (wrapper) {
             var toggle = wrapper.querySelector('.dropdown-toggle');

--- a/static/js/version-selector.js
+++ b/static/js/version-selector.js
@@ -8,6 +8,13 @@
 (function() {
     'use strict';
 
+    // Verbose init tracing, off by default so a normal load is quiet (#131).
+    // Enable with localStorage.setItem('plotDebug','1') then reload.
+    const DEBUG = (() => {
+        try { return localStorage.getItem('plotDebug') === '1'; } catch (e) { return false; }
+    })();
+    const dbg = (...args) => { if (DEBUG) console.log(...args); };
+
     let selectedVersion = null;  // null = latest version
     let availableVersions = [];
     let loadingPlots = new Set();
@@ -83,8 +90,8 @@
      * Initialize version selector on page load
      */
     async function initVersionSelector() {
-        console.log('Initializing version selector...');
-        console.log('Looking for version selector element...');
+        dbg('Initializing version selector...');
+        dbg('Looking for version selector element...');
 
         const selector = document.getElementById('version-selector');
         if (!selector) {
@@ -92,11 +99,11 @@
             return;
         }
 
-        console.log('Version selector element found:', selector);
+        dbg('Version selector element found:', selector);
 
         try {
             // Fetch available versions from API
-            console.log('Fetching versions from /api/versions...');
+            dbg('Fetching versions from /api/versions...');
             const response = await fetch('/api/versions');
             const data = await response.json();
 
@@ -106,7 +113,7 @@
             }
 
             availableVersions = data.versions;
-            console.log(`Loaded ${availableVersions.length} versions`);
+            dbg(`Loaded ${availableVersions.length} versions`);
 
             // Populate version selector dropdown
             populateVersionSelector();
@@ -117,7 +124,7 @@
             // Restore version from URL if present (must happen after options are populated)
             restoreVersionFromURL();
 
-            console.log('Version selector initialization complete!');
+            dbg('Version selector initialization complete!');
 
         } catch (error) {
             console.error('Error initializing version selector:', error);
@@ -151,7 +158,7 @@
             selector.appendChild(option);
         });
 
-        console.log('Version selector populated');
+        dbg('Version selector populated');
     }
 
     /**
@@ -162,7 +169,7 @@
         if (!selector) return;
 
         selector.addEventListener('change', handleVersionChange);
-        console.log('Event listeners set up');
+        dbg('Event listeners set up');
 
         setupAopAopThresholdSlider();
     }
@@ -197,34 +204,34 @@
             reloadPlot(plotName);
         });
 
-        console.log('AOP-AOP threshold slider wired');
+        dbg('AOP-AOP threshold slider wired');
     }
 
     /**
      * Handle version selection change
      */
     async function handleVersionChange(event) {
-        console.log('VERSION CHANGE EVENT FIRED!');
-        console.log('Event target:', event.target);
-        console.log('Event target value:', event.target.value);
+        dbg('VERSION CHANGE EVENT FIRED!');
+        dbg('Event target:', event.target);
+        dbg('Event target value:', event.target.value);
 
         const newVersion = event.target.value || null;  // Empty string = latest
 
-        console.log(`New version: "${newVersion}", Current version: "${selectedVersion}"`);
+        dbg(`New version: "${newVersion}", Current version: "${selectedVersion}"`);
 
         if (newVersion === selectedVersion) {
-            console.log('Version unchanged, skipping reload');
+            dbg('Version unchanged, skipping reload');
             return; // No change
         }
 
-        console.log(`Version changed: ${selectedVersion} → ${newVersion || 'latest'}`);
+        dbg(`Version changed: ${selectedVersion} → ${newVersion || 'latest'}`);
         selectedVersion = newVersion;
 
         // Update URL with version parameter
         updateURLState(selectedVersion || '');
 
         // Update UI to show selected version
-        console.log('Updating version banner...');
+        dbg('Updating version banner...');
         updateVersionBanner();
 
         // Dispatch version-changed event so data tables can reset
@@ -235,9 +242,9 @@
         updateMethodologyQueryUris(selectedVersion);
 
         // Reload all versioned plots
-        console.log('Starting plot reload...');
+        dbg('Starting plot reload...');
         await reloadVersionedPlots();
-        console.log('Plot reload complete!');
+        dbg('Plot reload complete!');
     }
 
     /**
@@ -298,13 +305,13 @@
      * Reload all versioned plots with the selected version
      */
     async function reloadVersionedPlots() {
-        console.log(`Reloading ${versionedPlots.length} plots for version: ${selectedVersion || 'latest'}`);
+        dbg(`Reloading ${versionedPlots.length} plots for version: ${selectedVersion || 'latest'}`);
 
         const reloadPromises = versionedPlots.map(plotName => reloadPlot(plotName));
 
         try {
             await Promise.all(reloadPromises);
-            console.log('All plots reloaded successfully');
+            dbg('All plots reloaded successfully');
         } catch (error) {
             console.error('Error reloading plots:', error);
         }
@@ -315,7 +322,7 @@
      */
     async function reloadPlot(plotName) {
         if (loadingPlots.has(plotName)) {
-            console.log(`Plot ${plotName} already loading, skipping...`);
+            dbg(`Plot ${plotName} already loading, skipping...`);
             return;
         }
 
@@ -331,7 +338,7 @@
         // Mark this plot as manually loaded so lazy-loader won't reload it
         if (window.plotLoader) {
             window.plotLoader.loadedPlots.add(plotName);
-            console.log(`Marked ${plotName} as loaded in lazy-loader cache`);
+            dbg(`Marked ${plotName} as loaded in lazy-loader cache`);
         }
 
         // Show loading spinner
@@ -348,7 +355,7 @@
             const qs = params.toString();
             const url = qs ? `/api/plot/${plotName}?${qs}` : `/api/plot/${plotName}`;
 
-            console.log(`Fetching plot from: ${url}`);
+            dbg(`Fetching plot from: ${url}`);
 
             const response = await fetch(url);
             const data = await response.json();
@@ -369,7 +376,7 @@
                     script.parentNode.replaceChild(newScript, script);
                 });
 
-                console.log(`Plot ${plotName} loaded successfully`);
+                dbg(`Plot ${plotName} loaded successfully`);
             } else {
                 throw new Error(data.error || 'Failed to load plot');
             }

--- a/templates/trends.html
+++ b/templates/trends.html
@@ -112,7 +112,7 @@
         </div>
         <p class="plot-description">
             Tracks which metadata properties are present in Key Events over time. Identifies completeness patterns and annotation trends.
-            Each property is shown in its own panel.
+            Each property is a line, distinguished by colour and marker shape.
         </p>
         {{ methodology_note(methodology_notes, 'ke_property_presence') }}
         <div class="abs">
@@ -154,7 +154,7 @@
         </div>
         <p class="plot-description">
             Tracks which metadata properties are present in Key Event Relationships over time. Monitors evidence and annotation quality.
-            Each property is shown in its own panel.
+            Each property is a line, distinguished by colour and marker shape.
         </p>
         {{ methodology_note(methodology_notes, 'ker_property_presence') }}
         <div class="abs">
@@ -196,7 +196,7 @@
         </div>
         <p class="plot-description">
             Tracks which metadata properties are present in Stressors over time. Identifies documentation patterns and completeness trends.
-            Each property is shown in its own panel.
+            Each property is a line, distinguished by colour and marker shape.
         </p>
         {{ methodology_note(methodology_notes, 'stressor_property_presence') }}
         <div class="abs">


### PR DESCRIPTION
Three changes: the property-presence chart rework you asked for, plus two small fixes surfaced while testing the checklist.

## 1. Property-presence charts → single chart, colour + shape (`bcc20a2`)

You didn't like the small-multiples "little boxes" (#130/#135). Reverted to **one line chart per figure**, with each property distinguished by **both colour and marker shape** — the 11-colour palette × 13 marker symbols makes every (colour, shape) pair unique well past any entity's property count (AOP has the most at ~17). The legend moves **below the plot and wraps**, so all series stay visible instead of scrolling inside the plot frame — which was the original #130 problem the facets were solving.

Kept both correctness fixes from #135:
- **No raw URI** in the legend — curated `License` row + `humanize_predicate_uri()` fallback.
- **Leading-zero mask** — a line starts when its property first appears (License: 24 leading nulls, starts 2024-04-01), not from a flat zero.

Descriptions and methodology notes updated to match ("each property is a line, distinguished by colour and marker shape").

## 2. Guard `target.closest` in download-dropdown.js (`c8f4662`)

The global click/keydown listeners called `event.target.closest()` directly. Real events target an Element, but a synthetic event can target `document`/`window`, which have no `.closest()` — that threw a `TypeError` (surfaced when I dispatched an Escape on `document` during testing). Guarded both sites via a `closestOn()` helper. No behaviour change for real events.

## 3. Quiet version-selector.js logs (`8df5c92`)

#131 gated the lazy-loader's 52 `console.log`s but left `version-selector.js` emitting ~9 more per load. Same `dbg()` gate now (enable with `localStorage.plotDebug=1`). A normal load is now fully quiet.

## Verification

Local instance on the live endpoint (41/41):
- **Single chart** (no facets), **13 distinct marker symbols**, horizontal wrapping legend, no raw-URI leak — confirmed for all four entities; all render `success: true`.
- License series: 24 leading nulls, first value 373 → still masked.
- Percentage view: y-axis 0–105.
- Both JS files pass `node --check`; guard verified; version-selector quiet.
- 30 tests pass; methodology-lint clean (55 entries, 0 failures); JSON valid.
