### PR TITLE
fix: layout, copy and label polish (#132)

### DIFF
--- a/plots/shared.py
+++ b/plots/shared.py
@@ -281,19 +281,19 @@ _vhp4safety_template = go.layout.Template(
             y=1.0,
             xanchor="left",
             x=1.02,
-            font=dict(size=11),
+            font=dict(size=12),
         ),
         xaxis=dict(
             gridcolor="#e0e0e0",
             linecolor="#cccccc",
             zeroline=False,
-            tickfont=dict(size=11),
+            tickfont=dict(size=12),
         ),
         yaxis=dict(
             gridcolor="#e0e0e0",
             linecolor="#cccccc",
             zeroline=False,
-            tickfont=dict(size=11),
+            tickfont=dict(size=12),
         ),
     )
 )

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -321,7 +321,13 @@ footer img {
     flex-wrap: wrap;
     gap: 5px;
     padding: 20px;
-    justify-content: center;
+    /* flex-start (not center) so an odd trailing card sits under the left
+       column instead of floating centred at half width, which read as a
+       different hierarchy level (#132). align-items:flex-start lets each card
+       size to its own content, so a short chart no longer leaves a tall blank
+       area matching its taller row-mate. */
+    justify-content: flex-start;
+    align-items: flex-start;
 }
 
 .plot-box {

--- a/templates/base.html
+++ b/templates/base.html
@@ -54,7 +54,7 @@
                     <img src="{{ url_for('static', filename='images/vhplogo.png') }}"
                          alt="VHP4Safety" class="footer-logo footer-logo-vhp">
                 </a>
-                <span class="footer-funding-text">This project which is funded by the Netherlands Research Council (NWO) &lsquo;Netherlands Research Agenda: Research on Routes by Consortia&rsquo; (NWA-ORC 1292.19.272)</span>
+                <span class="footer-funding-text">This project is funded by the Netherlands Research Council (NWO) &lsquo;Netherlands Research Agenda: Research on Routes by Consortia&rsquo; (NWA-ORC 1292.19.272)</span>
             </div>
         </div>
     </footer>

--- a/templates/latest.html
+++ b/templates/latest.html
@@ -370,17 +370,10 @@
                 <h3>AOP Coverage of Organ Systems</h3>
             </div>
             <p class="plot-description">
-                AOP coverage of 13 high-level organ systems, classified per AOP via a hybrid of four signals:
-                <strong>A</strong> (curated UBERON/CL anatomy on Key Events),
-                <strong>A&prime;</strong> (UBERON/CL appearing as biological-event objects),
-                <strong>B</strong> (GO biological-process bridge, curated map), and
-                <strong>C</strong> (regex on AOP title — exploratory, grey). Both views share one
-                scope toggle so they stay in sync; the View toggle (absolute/percentage) drives the
-                stacked bar only, while the bucket-totals bar always shows the AOP count per organ system.
-                <strong>Tip:</strong> the CSV download below contains <em>one row per AOP × bucket</em>
-                (columns: <code>AOP, AOP Title, AO URI, Organ System, Signals, Best Signal, Version, Scope</code>) —
-                including the "No annotation" bucket, which lists every AOP that the classifier could not place
-                under the current scope.
+                AOP coverage of 13 high-level organ systems, classified per AOP from curated
+                anatomy, biological-process, and title signals. Use the toggles below to change
+                which Key Events count and to switch between absolute counts and share of AOPs.
+                See <strong>Methodology</strong> for how each signal is derived and what the CSV contains.
             </p>
             <div class="coverage-toggle" data-scope="all" data-view="absolute">
                 <div class="coverage-toggle-row">

--- a/templates/trends.html
+++ b/templates/trends.html
@@ -15,7 +15,7 @@
                     </div>
                 </div>
                 <div class="download-dropdown">
-                    <button class="download-button dropdown-toggle">Download Delta ▼</button>
+                    <button class="download-button dropdown-toggle">Download Deltas ▼</button>
                     <div class="dropdown-menu">
                         <a href="/download/trend/aop_entity_counts_delta?format=csv" class="dropdown-item">📄 CSV</a>
                         <a href="/download/trend/aop_entity_counts_delta?format=png" class="dropdown-item">🖼️ PNG</a>
@@ -394,14 +394,14 @@
                     </div>
                 </div>
                 <div class="download-dropdown">
-                    <button class="download-button dropdown-toggle">Download Delta ▼</button>
+                    <button class="download-button dropdown-toggle">Download Deltas ▼</button>
                     <div class="dropdown-menu">
                         <a href="/download/trend/stressor_coverage_growth_delta?format=csv" class="dropdown-item">📄 CSV</a>
                         <a href="/download/trend/stressor_coverage_growth_delta?format=png" class="dropdown-item">🖼️ PNG</a>
                         <a href="/download/trend/stressor_coverage_growth_delta?format=svg" class="dropdown-item">📐 SVG</a>
                     </div>
                 </div>
-                <label><input type="checkbox" class="plot-toggle"> Show Delta</label>
+                <label><input type="checkbox" class="plot-toggle"> Show Deltas</label>
             </div>
         </div>
         <p class="plot-description">
@@ -606,7 +606,7 @@
                     </div>
                 </div>
                 <div class="download-dropdown">
-                    <button class="download-button dropdown-toggle">Download Delta ▼</button>
+                    <button class="download-button dropdown-toggle">Download Deltas ▼</button>
                     <div class="dropdown-menu">
                         <a href="/download/trend/average_components_per_aop_delta?format=csv" class="dropdown-item">📄 CSV</a>
                         <a href="/download/trend/average_components_per_aop_delta?format=png" class="dropdown-item">🖼️ PNG</a>
@@ -678,7 +678,7 @@
                     </div>
                 </div>
                 <div class="download-dropdown">
-                    <button class="download-button dropdown-toggle">Download Delta ▼</button>
+                    <button class="download-button dropdown-toggle">Download Deltas ▼</button>
                     <div class="dropdown-menu">
                         <a href="/download/trend/aop_authors_delta?format=csv" class="dropdown-item">📄 CSV</a>
                         <a href="/download/trend/aop_authors_delta?format=png" class="dropdown-item">🖼️ PNG</a>
@@ -770,7 +770,7 @@
                     </div>
                 </div>
                 <div class="download-dropdown">
-                    <button class="download-button dropdown-toggle">Download Delta ▼</button>
+                    <button class="download-button dropdown-toggle">Download Deltas ▼</button>
                     <div class="dropdown-menu">
                         <a href="/download/trend/ke_component_annotations_delta?format=csv" class="dropdown-item">📄 CSV</a>
                         <a href="/download/trend/ke_component_annotations_delta?format=png" class="dropdown-item">🖼️ PNG</a>
@@ -810,7 +810,7 @@
                     </div>
                 </div>
                 <div class="download-dropdown">
-                    <button class="download-button dropdown-toggle">Download Delta ▼</button>
+                    <button class="download-button dropdown-toggle">Download Deltas ▼</button>
                     <div class="dropdown-menu">
                         <a href="/download/trend/ke_components_percentage_delta?format=csv" class="dropdown-item">📄 CSV</a>
                         <a href="/download/trend/ke_components_percentage_delta?format=png" class="dropdown-item">🖼️ PNG</a>
@@ -850,7 +850,7 @@
                     </div>
                 </div>
                 <div class="download-dropdown">
-                    <button class="download-button dropdown-toggle">Download Delta ▼</button>
+                    <button class="download-button dropdown-toggle">Download Deltas ▼</button>
                     <div class="dropdown-menu">
                         <a href="/download/trend/unique_ke_components_delta?format=csv" class="dropdown-item">📄 CSV</a>
                         <a href="/download/trend/unique_ke_components_delta?format=png" class="dropdown-item">🖼️ PNG</a>
@@ -890,7 +890,7 @@
                     </div>
                 </div>
                 <div class="download-dropdown">
-                    <button class="download-button dropdown-toggle">Download Delta ▼</button>
+                    <button class="download-button dropdown-toggle">Download Deltas ▼</button>
                     <div class="dropdown-menu">
                         <a href="/download/trend/biological_process_annotations_delta?format=csv" class="dropdown-item">📄 CSV</a>
                         <a href="/download/trend/biological_process_annotations_delta?format=png" class="dropdown-item">🖼️ PNG</a>
@@ -930,7 +930,7 @@
                     </div>
                 </div>
                 <div class="download-dropdown">
-                    <button class="download-button dropdown-toggle">Download Delta ▼</button>
+                    <button class="download-button dropdown-toggle">Download Deltas ▼</button>
                     <div class="dropdown-menu">
                         <a href="/download/trend/biological_object_annotations_delta?format=csv" class="dropdown-item">📄 CSV</a>
                         <a href="/download/trend/biological_object_annotations_delta?format=png" class="dropdown-item">🖼️ PNG</a>
@@ -970,7 +970,7 @@
                     </div>
                 </div>
                 <div class="download-dropdown">
-                    <button class="download-button dropdown-toggle">Download Delta ▼</button>
+                    <button class="download-button dropdown-toggle">Download Deltas ▼</button>
                     <div class="dropdown-menu">
                         <a href="/download/trend/kes_by_kec_count_delta?format=csv" class="dropdown-item">📄 CSV</a>
                         <a href="/download/trend/kes_by_kec_count_delta?format=png" class="dropdown-item">🖼️ PNG</a>
@@ -1011,7 +1011,7 @@
                     </div>
                 </div>
                 <div class="download-dropdown">
-                    <button class="download-button dropdown-toggle">Download Delta ▼</button>
+                    <button class="download-button dropdown-toggle">Download Deltas ▼</button>
                     <div class="dropdown-menu">
                         <a href="/download/trend/ontology_term_growth_delta?format=csv" class="dropdown-item">📄 CSV</a>
                         <a href="/download/trend/ontology_term_growth_delta?format=png" class="dropdown-item">🖼️ PNG</a>
@@ -1130,7 +1130,7 @@ document.querySelectorAll(".plot-toggle").forEach(toggle => {
             const isDelta = this.classList.toggle("is-active");
             this.classList.toggle("active", isDelta);  // back-compat for any legacy CSS
             this.setAttribute("aria-pressed", isDelta ? "true" : "false");
-            this.textContent = isDelta ? "Switch to Absolute Mode" : "Switch to Delta Mode";
+            this.textContent = isDelta ? "Show absolute counts" : "Show Deltas";
 
             document.querySelectorAll(".plot-box").forEach(box => {
                 const abs = box.querySelector(".abs");

--- a/templates/trends_page.html
+++ b/templates/trends_page.html
@@ -19,7 +19,7 @@
         <button id="trends-range-reset" type="button" class="snapshot-topbar-pill" title="Reset to full range">Reset</button>
     </div>
     <div class="snapshot-topbar-mode">
-        <button id="toggle-delta" type="button" class="snapshot-topbar-pill snapshot-topbar-pill--toggle" aria-pressed="false">Switch to Delta Mode</button>
+        <button id="toggle-delta" type="button" class="snapshot-topbar-pill snapshot-topbar-pill--toggle" aria-pressed="false">Show Deltas</button>
     </div>
     <div class="snapshot-topbar-download">
         <div class="download-dropdown">
@@ -52,7 +52,7 @@
     <summary>About this page</summary>
     <p>
         Evolution and growth patterns of the AOP-Wiki database over time, using quarterly releases.
-        Toggle the global <strong>Delta Mode</strong> button at the top to switch every plot between absolute counts and per-version deltas, or use the per-plot checkbox.
+        Use the global <strong>Show Deltas</strong> toggle at the top to switch every plot between absolute counts and per-version deltas, or the per-plot checkbox.
         Use the <strong>Range</strong> selectors to constrain every snapshot-keyed plot to a sub-window; CSV/PNG/SVG downloads and the methodology "Run on Endpoint" queries honour the same window.
         Lifetime / creation-date plots are not affected by the range selector — their x-axis is creation year, not snapshot date.
     </p>


### PR DESCRIPTION
The low-severity polish from #132. I did the clean, unambiguous items and deliberately deferred two subjective/large ones (below).

## Shipped

- **Orphan cards** — `.plot-grid` was `justify-content: center`, so a section with an odd number of cards left the last one floating centred at half width, reading as a different hierarchy level. Now `flex-start`; verified the trailing card left-aligns on the odd-count grids.
- **Dead space in cards** — added `align-items: flex-start` so a short chart's card sizes to its own content instead of stretching to its taller row-mate. "Entity Counts" no longer trails ~180px of blank card.
- **Delta vocabulary** — unified to one verb+noun. The global pill now reads **"Show Deltas" / "Show absolute counts"**, matching the per-plot "Show Deltas" checkboxes; fixed a "Show Delta" singular slip; "Download Delta" → "Download Deltas"; intro text updated. Pill toggle + `aria-pressed` verified.
- **Chart font floor** — Plotly tick/legend text 11px → **12px** in the shared template (one place, all charts); verified a rendered tick at 12px.
- **Funding grammar** — "This project which is funded by" → "This project is funded by".
- **Organ-coverage description** — trimmed from a 7-line paragraph (signals A/A'/B/C, CSV columns, a "Tip:") to two sentences pointing at the Methodology panel directly below, which already carries all of that (verified: 358 chars, no "Tip:", links to Methodology).

## Deferred (kept #132 open)

- **Wholesale 45° tick → horizontal bar conversion.** "Nearly every categorical chart" overstates it — the flagged ones (OECD status ×4 short labels) are readable at 45°, and converting grouped verticals to horizontals touches many plot functions with real regression surface. Better done selectively, per chart, if wanted.
- **Landing-page growth-sparkline hero.** Subjective design addition; the landing already shows the six stat badges (my original "shows no data" was wrong for `main`). Worth doing as its own scoped change, not folded into a polish PR.

Also still tracked on #132 and not touched here: the stale `BRAND_COLORS['oecd_status']` map (two live statuses fall back to default colours) and the deployed-instance empty `entity_counts` from the first review.

## Verification

Local instance on the live endpoint (41/41): grid `justify-content: flex-start` + `align-items: flex-start`; orphan cards left-align; pill toggles "Show Deltas"↔"Show absolute counts"; tick font 12px; funding text fixed; organ description trimmed + Methodology pointer. 30 tests pass.
