### PR TITLE
fix: OECD status colours + landing counts self-heal (#139, #140)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1987,13 +1987,30 @@ def landing():
     from cached startup data. Includes expandable AOP-Wiki introduction.
     """
     latest_version = _latest_version or "Unknown"
-    entity_counts = None
-    cached_df = _plot_data_cache.get('latest_entity_counts')
-    if cached_df is not None and hasattr(cached_df, 'empty') and not cached_df.empty:
+
+    def _counts_from_cache():
+        cached_df = _plot_data_cache.get('latest_entity_counts')
+        if cached_df is not None and hasattr(cached_df, 'empty') and not cached_df.empty:
+            try:
+                return dict(zip(cached_df['Entity'], cached_df['Count']))
+            except (KeyError, TypeError):
+                return None
+        return None
+
+    entity_counts = _counts_from_cache()
+    if entity_counts is None:
+        # The counts come from the startup plot cache. If that computation failed
+        # during warmup (e.g. a SPARQL timeout), the cache stays empty and the
+        # landing badges would show nothing until the next restart. Recompute
+        # once on demand so the page self-heals (#140). safe_plot_execution
+        # swallows errors, so a still-down endpoint just leaves counts hidden
+        # rather than erroring the page.
         try:
-            entity_counts = dict(zip(cached_df['Entity'], cached_df['Count']))
-        except (KeyError, TypeError):
-            entity_counts = None
+            safe_plot_execution(plot_latest_entity_counts)
+            entity_counts = _counts_from_cache()
+        except Exception:
+            logger.warning("Landing: on-demand entity_counts recompute failed", exc_info=True)
+
     return render_template("landing.html", version=latest_version, entity_counts=entity_counts, active_page='home')
 
 

--- a/plots/shared.py
+++ b/plots/shared.py
@@ -227,16 +227,24 @@ BRAND_COLORS = {
         '#29235C', '#E6007E', '#307BBF', '#009FE3', '#EB5B25',
         '#93D5F6', '#9A1C57', '#45A6B2', '#B81178', '#005A6C', '#64358C',
     ],
-    # OECD Status color mapping — consistent across all OECD-related plots
+    # OECD Status color mapping — consistent across all OECD-related plots.
+    # Covers every status present across the 2018–2026 snapshots (the version
+    # selector renders historical graphs, which use older EAGMST/TFHA vocabulary
+    # no longer in the current release) plus the synthetic 'No Status' the code
+    # assigns to AOPs with no status. Verified against all graphs (2026-07): the
+    # eight real statuses below are exactly those in the data. Keep in sync if
+    # the OECD vocabulary changes. Ordered by rough workflow maturity so the
+    # colour progression reads sensibly (#139).
     'oecd_status': {
-        'EAGMST Under Review': '#307BBF',      # blue
-        'Under Development': '#009FE3',         # light blue
-        'TFHA/WNT Endorsed': '#29235C',         # primary (deep purple)
-        'WNT Endorsed': '#E6007E',              # magenta
-        'Approved': '#EB5B25',                  # orange
-        'No Status': '#999999',                 # grey
-        'EAGMST Under Development': '#45A6B2',  # teal
-        'Not OECD': '#93D5F6',                  # sky blue
+        'No Status': '#999999',                    # grey — no status assigned
+        'Included in OECD Work Plan': '#93D5F6',   # sky blue — earliest stage
+        'Under Development': '#009FE3',            # light blue
+        'Under Review': '#307BBF',                 # blue
+        'EAGMST Under Review': '#45A6B2',          # teal — EAGMST review variant
+        'EAGMST Approved': '#EB5B25',              # orange — approved
+        'TFHA/WNT Endorsed': '#29235C',            # deep purple — endorsed (legacy label)
+        'WPHA/WNT Endorsed': '#E6007E',            # magenta — endorsed (current label)
+        'Archived': '#777777',                     # dark grey — retired
     },
     # Legacy aliases for backward compatibility
     'secondary': '#E6007E',
@@ -244,11 +252,6 @@ BRAND_COLORS = {
     'light': '#93D5F6',
     'content': '#EB5B25',
     # Property type colors using house style palette
-    # NOTE: the 'oecd_status' map above is stale — the live data carries only
-    # 'Under Development', 'Under Review', 'WPHA/WNT Endorsed' and the synthetic
-    # 'No Status' (verified on 2026-07-01). Keys like 'EAGMST Under Review',
-    # 'TFHA/WNT Endorsed', 'Approved' and 'Not OECD' no longer occur, and the two
-    # statuses that do occur are missing. Tracked separately; see OECD_STATUS_ORDER.
     'type_colors': {
         'Essential': '#29235C',    # Primary Dark
         'Metadata': '#E6007E',     # Primary Magenta


### PR DESCRIPTION
Fixes the two follow-up issues split out of #132.

## #139 — OECD status colour map covers all historical statuses

`BRAND_COLORS['oecd_status']` was stale: it keyed on statuses that no longer occur (`WNT Endorsed`, `Approved`, `EAGMST Under Development`, `Not OECD`) and lacked current ones (`Under Review`, `WPHA/WNT Endorsed`), so those fell back to Plotly's default colours.

Key finding while fixing: the version selector renders **historical** snapshots, and older AOPs use older OECD vocabulary. Queried across **all** 2018–2026 graphs, the full status set is:

`No Status` (synthetic) · `Included in OECD Work Plan` · `Under Development` · `Under Review` · `EAGMST Under Review` · `EAGMST Approved` · `TFHA/WNT Endorsed` · `WPHA/WNT Endorsed` · `Archived`

So the map is now **extended to all nine** (not just swapped to the four current ones — that would have broken colouring on historical snapshots), each a distinct brand colour ordered by rough workflow maturity.

## #140 — landing counts self-heal on an empty cache

The landing badges read `entity_counts` only from the startup plot cache (`app.py`). If that computation failed during the ~65s warmup (a SPARQL timeout), the cache stayed empty and the badges showed nothing **until the next restart** — exactly the deployed-vs-local discrepancy from the review. The route now recomputes once on a cache miss via `safe_plot_execution` and re-reads, so it self-heals on the next hit. Errors are swallowed, so a still-down endpoint just hides the counts rather than erroring the page.

## Verification

- **#139**: map covers all 9 statuses, all distinct colours (asserted); no live status falls back to default.
- **#140**: injected an empty DataFrame into the cache — the very next landing request rendered all six badges (self-heal fires within the request).
- 30 tests pass.
